### PR TITLE
Add Dark Mode feature

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -139,7 +139,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -507,7 +506,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -556,9 +554,29 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1201,7 +1219,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2190,8 +2207,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
@@ -2669,7 +2685,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.168.22.tgz",
       "integrity": "sha512-W2LyfkfJtDCf//jOjZeUBWwOVl8iDRVTECpGHa2M28MT3T5/VVnjgicYNHR/ax0Filk1iU67MRjcjHheTYvK1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.161.6",
         "@tanstack/react-store": "^0.9.3",
@@ -2880,7 +2895,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3052,7 +3066,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3072,7 +3085,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3083,7 +3095,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3512,28 +3523,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
@@ -3566,19 +3555,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -3675,7 +3651,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3688,32 +3663,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -3906,14 +3855,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/cliui": {
       "version": "6.0.0",
@@ -4251,23 +4192,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -4276,17 +4200,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -4442,17 +4355,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -4525,7 +4427,6 @@
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4704,17 +4605,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4891,6 +4781,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/fabric/node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/fabric/node_modules/cssstyle": {
@@ -5335,14 +5241,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -5495,14 +5393,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5647,7 +5537,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5736,28 +5625,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
     "node_modules/indefinite-article": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/indefinite-article/-/indefinite-article-0.0.2.tgz",
@@ -5781,14 +5648,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -7371,20 +7230,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7396,17 +7241,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -7465,14 +7299,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/motion": {
       "version": "12.38.0",
@@ -7559,14 +7385,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -7575,42 +7393,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -8017,35 +7799,6 @@
         "url": "https://opencollective.com/preact"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prettier": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -8134,18 +7887,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -8260,29 +8001,11 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8292,7 +8015,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8789,7 +8511,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
       "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8978,33 +8699,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9108,17 +8802,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -9179,8 +8862,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -9212,38 +8894,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/chownr": {
@@ -9487,20 +9137,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -9545,7 +9181,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9808,7 +9443,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10085,7 +9719,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/frontend/src/components/artboard-resize-toolbar-control.tsx
+++ b/frontend/src/components/artboard-resize-toolbar-control.tsx
@@ -184,7 +184,7 @@ export default function ArtboardResizeToolbarControl({
         }}
       >
         <HugeiconsIcon icon={AspectRatioIcon} size={18} strokeWidth={1.75} />
-        <span className="max-w-[5.5rem] truncate text-left text-xs font-medium tabular-nums text-neutral-700 sm:max-w-none">
+        <span className="max-w-[5.5rem] truncate text-left text-xs font-medium tabular-nums text-[var(--text-muted)] sm:max-w-none">
           {label}
         </span>
       </button>
@@ -200,14 +200,14 @@ export default function ArtboardResizeToolbarControl({
             transform: `translateX(calc(-50% + ${shiftX}px))`,
           }}
         >
-          <p className="mb-2 text-[13px] font-medium text-neutral-800">
+          <p className="mb-2 text-[13px] font-medium text-[var(--text)]">
             Artboard size
           </p>
           <div className="relative -mx-3 mb-3 w-auto shrink-0">
             <div className="relative w-full shrink-0">
               <button
                 type="button"
-                className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[13px] font-medium text-neutral-800 hover:bg-black/[0.05]"
+                className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[13px] font-medium text-[var(--text)] hover:bg-[var(--hover)]"
                 aria-label="Artboard preset"
                 aria-expanded={presetOpen}
                 aria-haspopup="menu"
@@ -243,14 +243,14 @@ export default function ArtboardResizeToolbarControl({
                     role="menuitemradio"
                     aria-checked={!currentPreset}
                     className={[
-                      'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] outline-none transition-colors hover:bg-black/[0.05]',
-                      currentPreset ? 'text-neutral-700' : 'bg-black/[0.04] text-neutral-900',
+                      'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] outline-none transition-colors hover:bg-[var(--hover)]',
+                      currentPreset ? 'text-[var(--text-muted)]' : 'bg-[var(--hover)] text-[var(--text)]',
                     ].join(' ')}
                     onClick={() => setPresetOpen(false)}
                   >
                     <span className="truncate">Custom dimensions</span>
                     {!currentPreset ? (
-                      <span className="ml-auto text-[10px] font-medium uppercase tracking-[0.08em] text-neutral-500">
+                      <span className="ml-auto text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-subtle)]">
                         Current
                       </span>
                     ) : null}
@@ -264,8 +264,8 @@ export default function ArtboardResizeToolbarControl({
                         role="menuitemradio"
                         aria-checked={active}
                         className={[
-                          'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] outline-none transition-colors hover:bg-black/[0.05]',
-                          active ? 'bg-black/[0.04] text-neutral-900' : 'text-neutral-700',
+                          'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] outline-none transition-colors hover:bg-[var(--hover)]',
+                          active ? 'bg-[var(--hover)] text-[var(--text)]' : 'text-[var(--text-muted)]',
                         ].join(' ')}
                         onClick={() => {
                           setPresetOpen(false)
@@ -274,7 +274,7 @@ export default function ArtboardResizeToolbarControl({
                       >
                         <span className="truncate">{preset.label}</span>
                         {active ? (
-                          <span className="ml-auto text-[10px] font-medium uppercase tracking-[0.08em] text-neutral-500">
+                          <span className="ml-auto text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-subtle)]">
                             Current
                           </span>
                         ) : null}
@@ -285,11 +285,11 @@ export default function ArtboardResizeToolbarControl({
               ) : null}
             </div>
           </div>
-          <div className="mb-2 text-[12px] font-medium text-neutral-700">
+          <div className="mb-2 text-[12px] font-medium text-[var(--text-muted)]">
             Custom size
           </div>
           <div className="grid grid-cols-[1fr_auto_1fr_auto] items-end gap-2">
-            <label className="block text-[12px] font-medium text-neutral-700">
+            <label className="block text-[12px] font-medium text-[var(--text-muted)]">
               Width
               <DimensionInput
                 value={sizeDraftW}
@@ -307,10 +307,10 @@ export default function ArtboardResizeToolbarControl({
                 }}
               />
             </label>
-            <div className="flex h-9 items-center justify-center pb-[2px] text-neutral-300">
+            <div className="flex h-9 items-center justify-center pb-[2px] text-[var(--text-subtle)]">
               ×
             </div>
-            <label className="block text-[12px] font-medium text-neutral-700">
+            <label className="block text-[12px] font-medium text-[var(--text-muted)]">
               Height
               <DimensionInput
                 value={sizeDraftH}
@@ -333,8 +333,8 @@ export default function ArtboardResizeToolbarControl({
               className={[
                 'mt-1 flex h-9 w-9 items-center justify-center rounded-lg border transition-colors',
                 linked
-                  ? 'border-black/15 bg-black/[0.05] text-neutral-900'
-                  : 'border-black/10 bg-white text-neutral-600 hover:border-black/15',
+                  ? 'border-[var(--border-strong)] bg-[var(--hover)] text-[var(--text)]'
+                  : 'border-[var(--line)] bg-[var(--surface-overlay)] text-[var(--text-muted)] hover:border-[var(--border-strong)]',
               ].join(' ')}
               aria-label={
                 linked ? 'Unlink dimensions' : 'Link dimensions'
@@ -417,7 +417,7 @@ function DimensionInput({
           setEditing(false)
         }
       }}
-      className="mt-1 box-border h-9 w-full rounded-lg border border-black/20 bg-white px-2 text-center font-mono text-[13px] tabular-nums text-neutral-900 outline-none focus:ring-2 focus:ring-black/15"
+      className="theme-input mt-1 box-border h-9 w-full rounded-lg border px-2 text-center font-mono text-[13px] tabular-nums outline-none focus:ring-2 focus:ring-[var(--accent)]/25"
       aria-label={ariaLabel}
     />
   ) : (
@@ -428,7 +428,7 @@ function DimensionInput({
       aria-valuemax={max}
       aria-label={`${ariaLabel} — drag horizontally to change, double-click to type`}
       title="Drag to change size · Shift for faster steps · Double-click to type"
-      className="mt-1 flex h-9 w-full cursor-ew-resize select-none items-center justify-center rounded-lg border border-black/10 bg-white px-2 font-mono text-[13px] tabular-nums text-neutral-900 touch-none transition-colors hover:border-black/18"
+      className="theme-input mt-1 flex h-9 w-full cursor-ew-resize select-none items-center justify-center rounded-lg border px-2 font-mono text-[13px] tabular-nums touch-none transition-colors hover:border-[var(--button-secondary-border-hover)]"
       onPointerDown={(e) => {
         if (editing || e.button !== 0) return
         e.preventDefault()

--- a/frontend/src/components/canvas-zoom-slider.tsx
+++ b/frontend/src/components/canvas-zoom-slider.tsx
@@ -19,7 +19,7 @@ export default function CanvasZoomSlider({
 }: CanvasZoomSliderProps) {
   return (
     <div
-      className="flex items-center gap-3 rounded-xl bg-[var(--surface-subtle)] px-3 py-2 sm:bg-white/90 sm:shadow-[0_2px_12px_rgba(0,0,0,0.06)]"
+      className="theme-toolbar-shell flex items-center gap-3 rounded-xl border px-3 py-2"
       title="Drag to zoom. Click the percentage to fit the page in view."
     >
       <EditorRangeSlider
@@ -37,12 +37,12 @@ export default function CanvasZoomSlider({
           type="button"
           disabled={disabled}
           onClick={onFitRequest}
-          className="min-w-[2.75rem] text-left text-sm tabular-nums text-neutral-600 outline-none hover:text-neutral-900 disabled:pointer-events-none disabled:opacity-40"
+          className="min-w-[2.75rem] text-left text-sm tabular-nums text-[var(--text-muted)] outline-none hover:text-[var(--text)] disabled:pointer-events-none disabled:opacity-40"
         >
           {value}%
         </button>
       ) : (
-        <span className="min-w-[2.75rem] text-sm tabular-nums text-neutral-600">
+        <span className="min-w-[2.75rem] text-sm tabular-nums text-[var(--text-muted)]">
           {value}%
         </span>
       )}

--- a/frontend/src/components/delete-confirm-dialog.tsx
+++ b/frontend/src/components/delete-confirm-dialog.tsx
@@ -53,7 +53,7 @@ export default function DeleteConfirmDialog({
       }}
     >
       <div
-        className="absolute inset-0 bg-black/35 backdrop-blur-[2px]"
+        className="absolute inset-0 bg-[var(--overlay-backdrop)] backdrop-blur-[2px]"
         aria-hidden
       />
       <div
@@ -80,7 +80,7 @@ export default function DeleteConfirmDialog({
         <div className="mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-2">
           <button
             type="button"
-            className="inline-flex min-h-11 w-full items-center justify-center rounded-full border border-black/[0.14] bg-white px-6 py-2.5 text-[15px] font-medium text-[var(--text)] transition-colors hover:bg-black/[0.04] sm:w-auto"
+            className="theme-secondary-button inline-flex min-h-11 w-full items-center justify-center rounded-full border px-6 py-2.5 text-[15px] font-medium transition-colors sm:w-auto"
             onClick={onClose}
           >
             {cancelLabel}

--- a/frontend/src/components/editor-ai-panel.tsx
+++ b/frontend/src/components/editor-ai-panel.tsx
@@ -85,7 +85,7 @@ export default function EditorAiPanel({ open, onClose, controller }: Props) {
     <div
       data-avnac-chrome
       className={[
-        "pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,400px)] flex-col overflow-hidden rounded-3xl border border-black/[0.08] bg-white/95 backdrop-blur-md",
+        "theme-sidebar-panel pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,400px)] flex-col overflow-hidden rounded-3xl border backdrop-blur-md",
         "bottom-3",
         editorSidebarPanelLeftClass,
         editorSidebarPanelTopClass,
@@ -93,7 +93,7 @@ export default function EditorAiPanel({ open, onClose, controller }: Props) {
       role="dialog"
       aria-label="Magic"
     >
-      <div className="flex items-center justify-between border-b border-black/[0.06] px-3 py-2">
+      <div className="flex items-center justify-between border-b border-[var(--line)] px-3 py-2">
         <div className="flex items-center gap-2">
           <HugeiconsIcon
             icon={AiMagicIcon}
@@ -104,13 +104,13 @@ export default function EditorAiPanel({ open, onClose, controller }: Props) {
           <span className="avnac-ai-gradient-text text-sm font-semibold">
             Magic
           </span>
-          <span className="rounded-full bg-[var(--surface-subtle)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-neutral-500">
+          <span className="rounded-full bg-[var(--surface-subtle)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
             beta
           </span>
         </div>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06]"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)]"
           onClick={onClose}
           aria-label="Close magic"
         >
@@ -138,7 +138,7 @@ export default function EditorAiPanel({ open, onClose, controller }: Props) {
 
 function MissingKeyPlaceholder() {
   return (
-    <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4 text-sm text-neutral-700">
+    <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4 text-sm text-[var(--text-muted)]">
       <p>
         Magic uses{" "}
         <a
@@ -152,10 +152,10 @@ function MissingKeyPlaceholder() {
         to turn natural-language prompts into real edits on your artboard.
       </p>
       <p>To enable it, add a Tambo API key to your frontend env:</p>
-      <pre className="rounded-xl border border-black/[0.08] bg-[var(--surface-subtle)] p-3 text-[12px] text-neutral-800">
+      <pre className="rounded-xl border border-[var(--line)] bg-[var(--surface-subtle)] p-3 text-[12px] text-[var(--text)]">
         <code>VITE_TAMBO_API_KEY=your-key-here</code>
       </pre>
-      <p className="text-[12px] text-neutral-500">
+      <p className="text-[12px] text-[var(--text-muted)]">
         Get a free key at{" "}
         <a
           className="underline decoration-dotted underline-offset-2"
@@ -384,7 +384,7 @@ function MagicChat({ quickPrompts }: { quickPrompts: string[] }) {
 
       <form
         onSubmit={onSubmit}
-        className="mt-auto flex shrink-0 flex-col gap-2 border-t border-black/[0.06] px-3 pt-2 pb-1.5"
+        className="mt-auto flex shrink-0 flex-col gap-2 border-t border-[var(--line)] px-3 pt-2 pb-1.5"
       >
         <input
           ref={imageInputRef}
@@ -401,7 +401,7 @@ function MagicChat({ quickPrompts }: { quickPrompts: string[] }) {
             {stagedImages.map((img) => (
               <div
                 key={img.id}
-                className="relative h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-black/[0.08] bg-[var(--surface-subtle)]"
+                className="relative h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-[var(--line)] bg-[var(--surface-subtle)]"
               >
                 <img
                   src={img.dataUrl}
@@ -432,7 +432,7 @@ function MagicChat({ quickPrompts }: { quickPrompts: string[] }) {
           onKeyDown={onKeyDown}
           placeholder="Describe a design, change, or layout…"
           rows={2}
-          className="w-full resize-none rounded-xl border border-black/[0.08] bg-white px-3 py-2 text-sm text-neutral-800 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-[#8B3DFF]/25"
+          className="theme-input w-full resize-none rounded-xl border px-3 py-2 text-sm placeholder:text-[var(--text-subtle)] focus:outline-none focus:ring-2 focus:ring-[#8B3DFF]/25"
         />
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
@@ -440,7 +440,7 @@ function MagicChat({ quickPrompts }: { quickPrompts: string[] }) {
               type="button"
               disabled={busy}
               onClick={() => imageInputRef.current?.click()}
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06] disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)] disabled:cursor-not-allowed disabled:opacity-50"
               aria-label="Attach images"
               title="Attach images"
             >
@@ -450,7 +450,7 @@ function MagicChat({ quickPrompts }: { quickPrompts: string[] }) {
                 strokeWidth={1.75}
               />
             </button>
-            <span className="text-[11px] text-neutral-500">
+            <span className="text-[11px] text-[var(--text-muted)]">
               Enter to send · Shift+Enter for newline
             </span>
           </div>
@@ -484,7 +484,7 @@ function EmptyState({
 }) {
   return (
     <div className="flex flex-col gap-3">
-      <div className="rounded-2xl border border-dashed border-black/[0.1] bg-[var(--surface-subtle)] px-4 py-4">
+      <div className="rounded-2xl border border-dashed border-[var(--border-strong)] bg-[var(--surface-subtle)] px-4 py-4">
         <div className="flex items-start gap-2">
           <HugeiconsIcon
             icon={SparklesIcon}
@@ -496,7 +496,7 @@ function EmptyState({
             <div className="avnac-ai-gradient-text text-sm font-semibold">
               Design with prompts
             </div>
-            <p className="mt-1 text-[12.5px] leading-snug text-neutral-600">
+            <p className="mt-1 text-[12.5px] leading-snug text-[var(--text-muted)]">
               Describe a full layout, a single element, or an edit — Magic will
               place, resize, and style objects directly on your artboard.
             </p>
@@ -505,7 +505,7 @@ function EmptyState({
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <div className="px-1 text-[11px] font-semibold uppercase tracking-wide text-neutral-500">
+        <div className="px-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
           Try one
         </div>
         {prompts.map((p) => (
@@ -513,7 +513,7 @@ function EmptyState({
             key={p}
             type="button"
             onClick={() => onPick(p)}
-            className="flex items-start gap-2 rounded-xl border border-black/[0.08] bg-white px-3 py-2 text-left text-[12.5px] text-neutral-700 transition-colors hover:bg-[var(--surface-subtle)]"
+            className="flex items-start gap-2 rounded-xl border border-[var(--line)] bg-[var(--surface-overlay)] px-3 py-2 text-left text-[12.5px] text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-subtle)]"
           >
             <HugeiconsIcon
               icon={SparklesIcon}
@@ -531,13 +531,13 @@ function EmptyState({
 
 function ThinkingBubble() {
   return (
-    <div className="flex items-center gap-2 self-start rounded-2xl border border-black/[0.06] bg-[var(--surface-subtle)] px-3 py-2">
+    <div className="flex items-center gap-2 self-start rounded-2xl border border-[var(--line)] bg-[var(--surface-subtle)] px-3 py-2">
       <div className="flex gap-1">
         <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[#8B3DFF] [animation-delay:-0.25s]" />
         <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[#8B3DFF] [animation-delay:-0.1s]" />
         <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[#8B3DFF]" />
       </div>
-      <span className="text-[11.5px] text-neutral-500">Thinking…</span>
+      <span className="text-[11.5px] text-[var(--text-muted)]">Thinking…</span>
     </div>
   );
 }
@@ -565,7 +565,7 @@ function ChatMarkdown({ text }: { text: string }) {
               return (
                 <code
                   {...rest}
-                  className="rounded-md bg-black/[0.06] px-1 py-0.5 text-[0.92em]"
+                  className="rounded-md bg-[var(--hover)] px-1 py-0.5 text-[0.92em]"
                 >
                   {children}
                 </code>
@@ -578,7 +578,7 @@ function ChatMarkdown({ text }: { text: string }) {
             );
           },
           pre: ({ children }) => (
-            <pre className="my-2 overflow-x-auto rounded-xl border border-black/[0.08] bg-[var(--surface-subtle)] p-2.5 text-[12px] leading-relaxed">
+            <pre className="my-2 overflow-x-auto rounded-xl border border-[var(--line)] bg-[var(--surface-subtle)] p-2.5 text-[12px] leading-relaxed">
               {children}
             </pre>
           ),
@@ -644,7 +644,7 @@ function MessageBubble({ message }: { message: MessageLike }) {
       ].join(" ")}
     >
       {showToolActivity ? (
-        <div className="flex max-w-[85%] items-center gap-1.5 rounded-full border border-black/[0.06] bg-[var(--surface-subtle)] px-2 py-0.5 text-[10.5px] text-neutral-600">
+        <div className="flex max-w-[85%] items-center gap-1.5 rounded-full border border-[var(--line)] bg-[var(--surface-subtle)] px-2 py-0.5 text-[10.5px] text-[var(--text-muted)]">
           <HugeiconsIcon
             icon={ToolsIcon}
             size={11}
@@ -666,7 +666,7 @@ function MessageBubble({ message }: { message: MessageLike }) {
               key={i}
               src={src}
               alt=""
-              className="max-h-40 max-w-[min(100%,220px)] rounded-2xl border border-black/[0.08] bg-[var(--surface-subtle)] object-contain"
+              className="max-h-40 max-w-[min(100%,220px)] rounded-2xl border border-[var(--line)] bg-[var(--surface-subtle)] object-contain"
             />
           ))}
         </div>
@@ -677,7 +677,7 @@ function MessageBubble({ message }: { message: MessageLike }) {
             "max-w-[85%] rounded-2xl px-3 py-2 text-[13px] leading-snug",
             isUser
               ? "whitespace-pre-wrap bg-[#8B3DFF] text-white"
-              : "border border-black/[0.06] bg-white text-neutral-800",
+              : "border border-[var(--line)] bg-[var(--surface-overlay)] text-[var(--text)]",
           ].join(" ")}
         >
           {isUser ? text : <ChatMarkdown text={text} />}

--- a/frontend/src/components/editor-apps-panel.tsx
+++ b/frontend/src/components/editor-apps-panel.tsx
@@ -123,19 +123,19 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
     <div
       data-avnac-chrome
       className={[
-        'pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,340px)] max-h-[min(92dvh,720px)] flex-col overflow-hidden rounded-3xl border border-black/[0.08] bg-white/95 backdrop-blur-md',
+        'theme-sidebar-panel pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,340px)] max-h-[min(92dvh,720px)] flex-col overflow-hidden rounded-3xl border backdrop-blur-md',
         editorSidebarPanelLeftClass,
         editorSidebarPanelTopClass,
       ].join(' ')}
       role="dialog"
       aria-label="Apps"
     >
-      <div className="flex shrink-0 items-center justify-between border-b border-black/[0.06] px-3 py-2">
+      <div className="flex shrink-0 items-center justify-between border-b border-[var(--line)] px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
           {screen !== 'menu' ? (
             <button
               type="button"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06]"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)]"
               onClick={() => setScreen('menu')}
               aria-label="Back to apps"
             >
@@ -146,13 +146,13 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
               />
             </button>
           ) : null}
-          <span className="truncate text-sm font-semibold text-neutral-800">
+          <span className="truncate text-sm font-semibold text-[var(--text)]">
             {screen === 'menu' ? 'Apps' : 'QR code'}
           </span>
         </div>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06]"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)]"
           onClick={onClose}
           aria-label="Close apps"
         >
@@ -165,19 +165,19 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
           <button
             type="button"
             onClick={() => setScreen('qr-code')}
-            className="flex w-full items-center gap-3 rounded-2xl border border-black/[0.06] bg-white px-3 py-3 text-left transition-colors hover:bg-[var(--surface-subtle)]"
+            className="flex w-full items-center gap-3 rounded-2xl border border-[var(--line)] bg-[var(--surface-overlay)] px-3 py-3 text-left transition-colors hover:bg-[var(--surface-soft)]"
           >
             <HugeiconsIcon
               icon={QrCodeIcon}
               size={22}
               strokeWidth={1.75}
-              className="shrink-0 text-neutral-700"
+              className="shrink-0 text-[var(--text-muted)]"
             />
             <div className="min-w-0">
-              <div className="text-[13px] font-semibold text-neutral-900">
+              <div className="text-[13px] font-semibold text-[var(--text)]">
                 QR code
               </div>
-              <div className="text-[11.5px] text-neutral-500">
+              <div className="text-[11.5px] text-[var(--text-muted)]">
                 Encode a URL and place it on the artboard.
               </div>
             </div>
@@ -185,26 +185,26 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3">
-          <label className="block text-[11px] font-medium text-neutral-600">
+          <label className="block text-[11px] font-medium text-[var(--text-muted)]">
             URL
             <input
               type="url"
               value={qrUrl}
               onChange={(e) => setQrUrl(e.target.value)}
-              className="mt-1 h-10 w-full rounded-xl border border-black/[0.08] bg-white px-2.5 text-[13px] text-neutral-800 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/45"
+              className="theme-input mt-1 h-10 w-full rounded-xl border px-2.5 text-[13px] placeholder:text-[var(--text-subtle)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/45"
               placeholder="https://example.com"
               autoComplete="url"
               inputMode="url"
             />
           </label>
 
-          <details className="group rounded-xl border border-black/[0.08] bg-white">
+          <details className="group rounded-xl border border-[var(--line)] bg-[var(--surface-overlay)]">
             <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-3 [&::-webkit-details-marker]:hidden">
-              <span className="text-[13px] font-semibold text-neutral-900">
+              <span className="text-[13px] font-semibold text-[var(--text)]">
                 Customize
               </span>
               <span
-                className="flex size-7 shrink-0 items-center justify-center text-neutral-500 transition-transform duration-200 group-open:rotate-180"
+                className="flex size-7 shrink-0 items-center justify-center text-[var(--text-muted)] transition-transform duration-200 group-open:rotate-180"
                 aria-hidden
               >
                 <svg
@@ -225,9 +225,9 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
                 </svg>
               </span>
             </summary>
-            <div className="border-t border-black/[0.06] px-3 pb-3 pt-1">
+            <div className="border-t border-[var(--line)] px-3 pb-3 pt-1">
               <label className="flex cursor-pointer items-center justify-between gap-4 py-2.5">
-                <span className="text-[13px] text-neutral-900">Background color</span>
+                <span className="text-[13px] text-[var(--text)]">Background color</span>
                 <span className="relative size-9 shrink-0">
                   <input
                     type="color"
@@ -239,13 +239,13 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
                     aria-label="QR background color"
                   />
                   <span
-                    className="pointer-events-none block size-9 rounded-full border border-black/[0.12] bg-white shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]"
+                    className="pointer-events-none block size-9 rounded-full border border-[var(--border-strong)] bg-[var(--surface-overlay-strong)] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]"
                     style={{ backgroundColor: qrColors.light }}
                   />
                 </span>
               </label>
               <label className="flex cursor-pointer items-center justify-between gap-4 py-2.5">
-                <span className="text-[13px] text-neutral-900">Foreground color</span>
+                <span className="text-[13px] text-[var(--text)]">Foreground color</span>
                 <span className="relative size-9 shrink-0">
                   <input
                     type="color"
@@ -257,7 +257,7 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
                     aria-label="QR foreground color"
                   />
                   <span
-                    className="pointer-events-none block size-9 rounded-full border border-black/[0.12] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]"
+                    className="pointer-events-none block size-9 rounded-full border border-[var(--border-strong)] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]"
                     style={{ backgroundColor: qrColors.dark }}
                   />
                 </span>
@@ -270,27 +270,27 @@ export default function EditorAppsPanel({ open, onClose, controller }: Props) {
           ) : null}
 
           {qrPreview ? (
-            <div className="flex justify-center rounded-xl border border-black/[0.06] bg-white p-3">
+            <div className="flex justify-center rounded-xl border border-[var(--line)] bg-[var(--surface-overlay)] p-3">
               <img
                 src={qrPreview}
                 alt="QR code preview"
                 width={200}
                 height={200}
-                className="size-[200px] max-w-full bg-white"
+                className="size-[200px] max-w-full bg-[var(--surface-overlay-strong)]"
               />
             </div>
           ) : (
-            <p className="text-center text-[12px] text-neutral-500">
+            <p className="text-center text-[12px] text-[var(--text-muted)]">
               Enter a URL to see a live preview.
             </p>
           )}
 
-          <div className="mt-auto border-t border-black/[0.06] pt-2">
+          <div className="mt-auto border-t border-[var(--line)] pt-2">
             <button
               type="button"
               disabled={adding || !qrUrl.trim() || !qrPreview}
               onClick={() => void addQrToCanvas()}
-              className="w-full rounded-xl bg-[var(--text)] px-3 py-2.5 text-[13px] font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+              className="theme-primary-button w-full rounded-xl px-3 py-2.5 text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
             >
               {adding ? 'Adding…' : 'Add to canvas'}
             </button>

--- a/frontend/src/components/editor-export-menu.tsx
+++ b/frontend/src/components/editor-export-menu.tsx
@@ -22,11 +22,11 @@ const DEFAULT_EXPORT: ExportPngOptions = {
 const PANEL_ESTIMATE_H = 220;
 
 const exportTriggerClass = [
-  "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/[0.08] px-4 text-sm font-medium sm:h-10 sm:px-5",
-  "bg-gradient-to-br from-[#fafaf9] via-[#f2f0f3] to-[#ebe7f3]",
+  "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-full border border-[var(--line)] px-4 text-sm font-medium sm:h-10 sm:px-5",
+  "bg-[linear-gradient(135deg,var(--surface-overlay-strong)_0%,var(--surface-soft)_55%,var(--surface-subtle)_100%)]",
   "text-[var(--text)] shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
   "outline-none transition-[background,box-shadow,filter] duration-200",
-  "hover:from-[#f5f4f2] hover:via-[#eceaf1] hover:to-[#e5e0f2] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)]",
+  "hover:shadow-[0_2px_8px_rgba(0,0,0,0.12)]",
   "focus-visible:ring-2 focus-visible:ring-[var(--accent)]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface)]",
   "disabled:pointer-events-none disabled:opacity-40",
 ].join(" ");
@@ -79,7 +79,7 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
           icon={FileExportIcon}
           size={18}
           strokeWidth={1.75}
-          className="shrink-0 text-neutral-800"
+          className="shrink-0 text-[var(--text)]"
         />
         <span className="text-[var(--text)]">Export</span>
       </button>
@@ -98,10 +98,10 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
           aria-label="Export"
         >
           <div className="mb-3 flex items-center justify-between gap-3">
-            <span className="text-[13px] font-medium text-neutral-800">
+            <span className="text-[13px] font-medium text-[var(--text)]">
               Export scale
             </span>
-            <span className="text-[13px] tabular-nums text-neutral-600">
+            <span className="text-[13px] tabular-nums text-[var(--text-muted)]">
               {mult}×
             </span>
           </div>
@@ -119,7 +119,7 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
             aria-valuenow={mult}
             trackClassName="mb-4 w-full"
           />
-          <label className="mb-4 flex cursor-pointer items-center gap-2.5 text-[13px] text-neutral-800">
+          <label className="mb-4 flex cursor-pointer items-center gap-2.5 text-[13px] text-[var(--text)]">
             <input
               type="checkbox"
               checked={opts.transparent}
@@ -133,7 +133,7 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
           </label>
           <button
             type="button"
-            className="w-full rounded-lg bg-neutral-900 py-2.5 text-[13px] font-medium text-white transition-colors hover:bg-neutral-800"
+            className="theme-primary-button w-full rounded-lg py-2.5 text-[13px] font-medium transition-colors"
             onClick={() => {
               const finalOpts = { ...opts, multiplier: mult };
               posthog.capture("png_exported", {

--- a/frontend/src/components/editor-floating-sidebar.tsx
+++ b/frontend/src/components/editor-floating-sidebar.tsx
@@ -48,7 +48,7 @@ export default function EditorFloatingSidebar({
       data-avnac-chrome
       aria-label="Editor tools"
       className={[
-        'pointer-events-auto fixed left-3 top-[calc(0.75rem+2.5rem+0.75rem+1px+0.75rem)] z-[45] flex flex-col gap-0.5 rounded-3xl border border-black/[0.08] bg-neutral-100/95 p-1.5 backdrop-blur-md sm:top-[calc(0.875rem+2.5rem+0.875rem+1px+0.75rem)]',
+        'pointer-events-auto fixed left-3 top-[calc(0.75rem+2.5rem+0.75rem+1px+0.75rem)] z-[45] flex flex-col gap-0.5 rounded-3xl border border-[var(--line)] bg-[var(--surface-panel)] p-1.5 backdrop-blur-md sm:top-[calc(0.875rem+2.5rem+0.875rem+1px+0.75rem)]',
         disabled ? 'pointer-events-none opacity-40' : '',
       ]
         .filter(Boolean)
@@ -93,8 +93,8 @@ export default function EditorFloatingSidebar({
             className={[
               'flex w-[4.25rem] flex-col items-center gap-1 rounded-2xl px-1.5 py-2.5 text-[11px] font-medium transition-colors',
               active
-                ? 'bg-white text-neutral-900'
-                : 'text-neutral-600 hover:bg-white/70 hover:text-neutral-900',
+                ? 'bg-[var(--surface-overlay-strong)] text-[var(--text)]'
+                : 'text-[var(--text-muted)] hover:bg-[var(--surface-soft)] hover:text-[var(--text)]',
               disabled ? 'cursor-not-allowed' : '',
             ].join(' ')}
           >
@@ -102,7 +102,7 @@ export default function EditorFloatingSidebar({
               icon={item.icon}
               size={22}
               strokeWidth={1.65}
-              className="shrink-0 text-neutral-700"
+              className="shrink-0 text-[var(--text-muted)]"
             />
             <span className="max-w-full truncate">{item.label}</span>
           </button>

--- a/frontend/src/components/editor-images-panel.tsx
+++ b/frontend/src/components/editor-images-panel.tsx
@@ -136,22 +136,22 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
     <div
       data-avnac-chrome
       className={[
-        'pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,340px)] max-h-[min(92dvh,720px)] flex-col overflow-hidden rounded-3xl border border-black/[0.08] bg-white/95 backdrop-blur-md',
+        'theme-sidebar-panel pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,340px)] max-h-[min(92dvh,720px)] flex-col overflow-hidden rounded-3xl border backdrop-blur-md',
         editorSidebarPanelLeftClass,
         editorSidebarPanelTopClass,
       ].join(' ')}
       role="dialog"
       aria-label="Images"
     >
-      <div className="flex shrink-0 items-start justify-between border-b border-black/[0.06] px-3 py-2">
+      <div className="flex shrink-0 items-start justify-between border-b border-[var(--line)] px-3 py-2">
         <div className="min-w-0">
-          <div className="text-sm font-semibold text-neutral-800">Images</div>
-          <p className="mt-0.5 text-[11px] text-neutral-500">
+          <div className="text-sm font-semibold text-[var(--text)]">Images</div>
+          <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
             <a
               href={unsplashReferralLink('https://unsplash.com/')}
               target="_blank"
               rel="noreferrer"
-              className="text-neutral-600 underline-offset-2 hover:underline"
+              className="text-[var(--text-muted)] underline-offset-2 hover:underline"
             >
               Powered by Unsplash
             </a>
@@ -159,7 +159,7 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
         </div>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06]"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)]"
           onClick={onClose}
           aria-label="Close images"
         >
@@ -168,14 +168,14 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div className="shrink-0 border-b border-black/[0.06] p-2">
+          <div className="shrink-0 border-b border-[var(--line)] p-2">
             <label className="relative block">
               <span className="sr-only">Search Unsplash</span>
               <HugeiconsIcon
                 icon={Search01Icon}
                 size={16}
                 strokeWidth={1.75}
-                className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-neutral-400"
+                className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-subtle)]"
               />
               <input
                 type="search"
@@ -183,7 +183,7 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Search Unsplash…"
                 autoComplete="off"
-                className="h-10 w-full rounded-xl border border-black/[0.08] bg-white pl-9 pr-3 text-[13px] text-neutral-800 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/45"
+                className="theme-input h-10 w-full rounded-xl border pl-9 pr-3 text-[13px] placeholder:text-[var(--text-subtle)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/45"
               />
             </label>
           </div>
@@ -194,7 +194,7 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
             ) : null}
 
             {photos.length === 0 && !loading && !error ? (
-              <p className="px-1 py-6 text-center text-[12px] text-neutral-500">
+              <p className="px-1 py-6 text-center text-[12px] text-[var(--text-muted)]">
                 No photos found.
               </p>
             ) : (
@@ -212,9 +212,9 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
                         type="button"
                         disabled={busy}
                         onClick={() => void addPhoto(photo)}
-                        className="group flex w-full flex-col overflow-hidden rounded-xl border border-black/[0.06] bg-white text-left transition-colors hover:border-black/[0.12] disabled:opacity-60"
+                        className="group flex w-full flex-col overflow-hidden rounded-xl border border-[var(--line)] bg-[var(--surface-overlay)] text-left transition-colors hover:border-[var(--border-strong)] disabled:opacity-60"
                       >
-                        <span className="relative aspect-[4/3] w-full overflow-hidden bg-neutral-100">
+                        <span className="relative aspect-[4/3] w-full overflow-hidden bg-[var(--surface-subtle)]">
                           <img
                             src={photo.urls.small}
                             alt={label}
@@ -227,18 +227,18 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
                             </span>
                           ) : null}
                         </span>
-                        <span className="border-t border-black/[0.06] px-1.5 py-1.5">
-                          <span className="line-clamp-2 text-[10.5px] leading-snug text-neutral-600">
+                        <span className="border-t border-[var(--line)] px-1.5 py-1.5">
+                          <span className="line-clamp-2 text-[10.5px] leading-snug text-[var(--text-muted)]">
                             <a
                               href={profileUrl}
                               target="_blank"
                               rel="noreferrer"
-                              className="font-medium text-neutral-800 underline-offset-2 hover:underline"
+                              className="font-medium text-[var(--text)] underline-offset-2 hover:underline"
                               onClick={(e) => e.stopPropagation()}
                             >
                               {photo.user.name}
                             </a>
-                            <span className="text-neutral-400"> on </span>
+                            <span className="text-[var(--text-subtle)]"> on </span>
                             <a
                               href={unsplashReferralLink('https://unsplash.com/')}
                               target="_blank"
@@ -265,7 +265,7 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
                   onClick={() =>
                     setCommitted((c) => ({ ...c, page: c.page + 1 }))
                   }
-                  className="w-full rounded-xl border border-black/[0.08] bg-[var(--surface-subtle)] px-3 py-2 text-[12px] font-medium text-neutral-800 transition-colors hover:bg-black/[0.06] disabled:cursor-not-allowed disabled:opacity-50"
+                  className="w-full rounded-xl border border-[var(--line)] bg-[var(--surface-subtle)] px-3 py-2 text-[12px] font-medium text-[var(--text)] transition-colors hover:bg-[var(--hover)] disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {loadingMore ? 'Loading…' : 'Load more'}
                 </button>
@@ -273,7 +273,7 @@ export default function EditorImagesPanel({ open, onClose, controller }: Props) 
             ) : null}
 
             {loading && photos.length === 0 ? (
-              <p className="py-8 text-center text-[12px] text-neutral-500">Loading…</p>
+              <p className="py-8 text-center text-[12px] text-[var(--text-muted)]">Loading…</p>
             ) : null}
           </div>
       </div>

--- a/frontend/src/components/editor-layers-panel.tsx
+++ b/frontend/src/components/editor-layers-panel.tsx
@@ -55,7 +55,7 @@ function LayerRowLabelControl({
     return (
       <input
         type="text"
-        className="min-w-0 flex-1 rounded-md border border-black/15 bg-white px-2 py-1 text-sm text-neutral-800 outline-none focus:border-black/30"
+        className="theme-input min-w-0 flex-1 rounded-md border px-2 py-1 text-sm outline-none focus:border-[var(--button-secondary-border-hover)]"
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={() => {
@@ -82,7 +82,7 @@ function LayerRowLabelControl({
   return (
     <button
       type="button"
-      className="flex min-w-0 flex-1 items-center gap-2 px-1 py-1.5 text-left text-sm text-neutral-800"
+      className="flex min-w-0 flex-1 items-center gap-2 px-1 py-1.5 text-left text-sm text-[var(--text)]"
       onClick={() => onSelectLayer(row.index)}
       title={onRenameLayer ? 'Double-click to rename' : undefined}
     >
@@ -105,7 +105,7 @@ function LayerRowLabelControl({
 function layerRowClass(selected: boolean) {
   return [
     'flex items-center gap-0.5 rounded-lg py-0.5',
-    selected ? 'bg-[var(--accent)]/20' : 'hover:bg-black/[0.04]',
+    selected ? 'bg-[var(--accent)]/20' : 'hover:bg-[var(--hover)]',
   ].join(' ')
 }
 
@@ -149,7 +149,7 @@ function LayerReorderRow({
         tabIndex={0}
         aria-label={`Reorder ${row.label}`}
         title="Drag to reorder"
-        className="flex h-8 w-7 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-neutral-400 hover:bg-black/[0.06] hover:text-neutral-600 active:cursor-grabbing"
+        className="flex h-8 w-7 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-[var(--text-subtle)] hover:bg-[var(--hover)] hover:text-[var(--text-muted)] active:cursor-grabbing"
         onPointerDown={onHandlePointerDown}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') e.preventDefault()
@@ -168,7 +168,7 @@ function LayerReorderRow({
       />
       <button
         type="button"
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-neutral-600 hover:bg-black/[0.06]"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--hover)]"
         title={row.visible ? 'Hide' : 'Show'}
         aria-label={row.visible ? 'Hide layer' : 'Show layer'}
         onClick={() => onToggleVisible(row.index)}
@@ -181,7 +181,7 @@ function LayerReorderRow({
       </button>
       <button
         type="button"
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-neutral-600 hover:bg-black/[0.06]"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--hover)]"
         title="Forward"
         aria-label="Bring forward"
         onClick={() => onBringForward(row.index)}
@@ -190,7 +190,7 @@ function LayerReorderRow({
       </button>
       <button
         type="button"
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-neutral-600 hover:bg-black/[0.06]"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--hover)]"
         title="Backward"
         aria-label="Send backward"
         onClick={() => onSendBackward(row.index)}
@@ -225,7 +225,7 @@ function StaticLayerRow({
       />
       <button
         type="button"
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-neutral-600 hover:bg-black/[0.06]"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--hover)]"
         title={row.visible ? 'Hide' : 'Show'}
         aria-label={row.visible ? 'Hide layer' : 'Show layer'}
         onClick={() => onToggleVisible(row.index)}
@@ -238,7 +238,7 @@ function StaticLayerRow({
       </button>
       <button
         type="button"
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-neutral-600 hover:bg-black/[0.06]"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--hover)]"
         title="Forward"
         aria-label="Bring forward"
         onClick={() => onBringForward(row.index)}
@@ -247,7 +247,7 @@ function StaticLayerRow({
       </button>
       <button
         type="button"
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-neutral-600 hover:bg-black/[0.06]"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--hover)]"
         title="Backward"
         aria-label="Send backward"
         onClick={() => onSendBackward(row.index)}
@@ -277,18 +277,18 @@ export default function EditorLayersPanel({
     <div
       data-avnac-chrome
       className={[
-        'pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,280px)] flex-col overflow-hidden rounded-3xl border border-black/[0.08] bg-white/95 backdrop-blur-md',
+        'theme-sidebar-panel pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,280px)] flex-col overflow-hidden rounded-3xl border backdrop-blur-md',
         editorSidebarPanelLeftClass,
         editorSidebarPanelTopClass,
       ].join(' ')}
       role="dialog"
       aria-label="Layers"
     >
-      <div className="flex items-center justify-between border-b border-black/[0.06] px-3 py-2">
-        <span className="text-sm font-semibold text-neutral-800">Layers</span>
+      <div className="flex items-center justify-between border-b border-[var(--line)] px-3 py-2">
+        <span className="text-sm font-semibold text-[var(--text)]">Layers</span>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06]"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)]"
           onClick={onClose}
           aria-label="Close layers"
         >
@@ -297,7 +297,7 @@ export default function EditorLayersPanel({
       </div>
       {rows.length === 0 ? (
         <ul className={listClass}>
-          <li className="px-3 py-6 text-center text-sm text-neutral-500">
+          <li className="px-3 py-6 text-center text-sm text-[var(--text-muted)]">
             No objects yet
           </li>
         </ul>

--- a/frontend/src/components/editor-range-slider.tsx
+++ b/frontend/src/components/editor-range-slider.tsx
@@ -5,11 +5,11 @@ export const editorRangeInputClassName = [
   '[&::-webkit-slider-runnable-track]:h-0 [&::-webkit-slider-runnable-track]:bg-transparent',
   '[&::-webkit-slider-thumb]:-mt-2.5 [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5',
   '[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-0',
-  '[&::-webkit-slider-thumb]:bg-white',
+  '[&::-webkit-slider-thumb]:bg-[var(--text-muted)]',
   '[&::-webkit-slider-thumb]:shadow-[0_2px_8px_rgba(59,130,246,0.14),0_1px_4px_rgba(0,0,0,0.12)]',
   '[&::-moz-range-track]:h-0 [&::-moz-range-track]:bg-transparent',
   '[&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0',
-  '[&::-moz-range-thumb]:bg-white',
+  '[&::-moz-range-thumb]:bg-[var(--text-muted)]',
   '[&::-moz-range-thumb]:shadow-[0_2px_8px_rgba(59,130,246,0.14),0_1px_4px_rgba(0,0,0,0.12)]',
 ].join(' ')
 
@@ -50,15 +50,15 @@ export default function EditorRangeSlider({
         .join(' ')}
     >
       <div
-        className="pointer-events-none absolute left-2 right-2 top-1/2 h-px -translate-y-1/2 bg-neutral-300/90"
+        className="pointer-events-none absolute left-2 right-2 top-1/2 h-px -translate-y-1/2 bg-[var(--border-strong)]"
         aria-hidden
       />
       <div
-        className="pointer-events-none absolute left-2 top-1/2 size-[5px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-500"
+        className="pointer-events-none absolute left-2 top-1/2 size-[5px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--text-subtle)]"
         aria-hidden
       />
       <div
-        className="pointer-events-none absolute right-2 top-1/2 size-[5px] translate-x-1/2 -translate-y-1/2 rounded-full bg-neutral-500"
+        className="pointer-events-none absolute right-2 top-1/2 size-[5px] translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--text-subtle)]"
         aria-hidden
       />
       <input

--- a/frontend/src/components/editor-uploads-panel.tsx
+++ b/frontend/src/components/editor-uploads-panel.tsx
@@ -17,25 +17,25 @@ export default function EditorUploadsPanel({ open, onClose }: Props) {
     <div
       data-avnac-chrome
       className={[
-        'pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,280px)] flex-col overflow-hidden rounded-3xl border border-black/[0.08] bg-white/95 backdrop-blur-md',
+        'theme-sidebar-panel pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,280px)] flex-col overflow-hidden rounded-3xl border backdrop-blur-md',
         editorSidebarPanelLeftClass,
         editorSidebarPanelTopClass,
       ].join(' ')}
       role="dialog"
       aria-label="Uploads"
     >
-      <div className="flex items-center justify-between border-b border-black/[0.06] px-3 py-2">
-        <span className="text-sm font-semibold text-neutral-800">Uploads</span>
+      <div className="flex items-center justify-between border-b border-[var(--line)] px-3 py-2">
+        <span className="text-sm font-semibold text-[var(--text)]">Uploads</span>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06]"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)]"
           onClick={onClose}
           aria-label="Close uploads"
         >
           <HugeiconsIcon icon={Cancel01Icon} size={18} strokeWidth={1.75} />
         </button>
       </div>
-      <div className="px-3 py-8 text-center text-sm text-neutral-500">
+      <div className="px-3 py-8 text-center text-sm text-[var(--text-muted)]">
         Coming soon
       </div>
     </div>

--- a/frontend/src/components/editor-vector-board-panel.tsx
+++ b/frontend/src/components/editor-vector-board-panel.tsx
@@ -38,20 +38,20 @@ export default function EditorVectorBoardPanel({
     <div
       data-avnac-chrome
       className={[
-        'pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,300px)] flex-col overflow-hidden rounded-3xl border border-black/[0.08] bg-white/95 backdrop-blur-md',
+        'theme-sidebar-panel pointer-events-auto fixed z-40 flex w-[min(100vw-1.5rem,300px)] flex-col overflow-hidden rounded-3xl border backdrop-blur-md',
         editorSidebarPanelLeftClass,
         editorSidebarPanelTopClass,
       ].join(' ')}
       role="dialog"
       aria-label="Vector boards"
     >
-      <div className="flex items-center justify-between border-b border-black/[0.06] px-3 py-2">
-        <span className="text-sm font-semibold text-neutral-800">
+      <div className="flex items-center justify-between border-b border-[var(--line)] px-3 py-2">
+        <span className="text-sm font-semibold text-[var(--text)]">
           Vector boards
         </span>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 hover:bg-black/[0.06]"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--hover)]"
           onClick={onClose}
           aria-label="Close vector boards"
         >
@@ -60,7 +60,7 @@ export default function EditorVectorBoardPanel({
       </div>
       <div className="flex max-h-[min(50vh,360px)] flex-col gap-2 overflow-auto p-2">
         {boards.length === 0 ? (
-          <p className="px-2 py-6 text-center text-sm text-neutral-500">
+          <p className="px-2 py-6 text-center text-sm text-[var(--text-muted)]">
             No vector boards yet.
           </p>
         ) : (
@@ -70,7 +70,7 @@ export default function EditorVectorBoardPanel({
               const hasContent = vectorDocHasRenderableStrokes(doc)
               return (
                 <li key={b.id}>
-                  <div className="flex items-center gap-2 rounded-xl border border-black/[0.06] bg-neutral-50/80 p-2">
+                  <div className="flex items-center gap-2 rounded-xl border border-[var(--line)] bg-[var(--surface-soft)] p-2">
                     <div
                       draggable={hasContent}
                       onDragStart={(e) => {
@@ -82,7 +82,7 @@ export default function EditorVectorBoardPanel({
                         e.dataTransfer.effectAllowed = 'copy'
                       }}
                       className={[
-                        'shrink-0 overflow-hidden rounded-lg border border-black/10 bg-white shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]',
+                        'shrink-0 overflow-hidden rounded-lg border border-[var(--border-strong)] bg-[var(--surface-overlay-strong)] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]',
                         hasContent
                           ? 'cursor-grab active:cursor-grabbing'
                           : 'cursor-not-allowed opacity-50',
@@ -97,17 +97,17 @@ export default function EditorVectorBoardPanel({
                     </div>
                     <button
                       type="button"
-                      className="min-w-0 flex-1 rounded-lg px-2 py-1.5 text-left text-sm text-neutral-800 transition-colors hover:bg-white/80"
+                      className="min-w-0 flex-1 rounded-lg px-2 py-1.5 text-left text-sm text-[var(--text)] transition-colors hover:bg-[var(--surface-soft-hover)]"
                       onClick={() => onOpenBoard(b.id)}
                     >
                       <span className="block truncate font-medium">{b.name}</span>
-                      <span className="mt-0.5 block text-[11px] text-neutral-500">
+                      <span className="mt-0.5 block text-[11px] text-[var(--text-muted)]">
                         {hasContent ? 'Click to edit · drag preview to place' : 'Click to edit'}
                       </span>
                     </button>
                     <button
                       type="button"
-                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-neutral-500 transition-colors hover:bg-red-50 hover:text-red-600"
+                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[var(--text-muted)] transition-colors hover:bg-red-500/10 hover:text-red-500"
                       title="Delete vector board"
                       aria-label={`Delete ${b.name}`}
                       onClick={(e) => {
@@ -124,10 +124,10 @@ export default function EditorVectorBoardPanel({
           </ul>
         )}
       </div>
-      <div className="border-t border-black/[0.06] p-2">
+      <div className="border-t border-[var(--line)] p-2">
         <button
           type="button"
-          className="flex w-full items-center justify-center gap-2 rounded-xl bg-neutral-900 py-2.5 text-sm font-medium text-white transition-colors hover:bg-neutral-800"
+          className="theme-primary-button flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium transition-colors"
           onClick={onCreateNew}
         >
           <HugeiconsIcon icon={Add01Icon} size={18} strokeWidth={1.75} />

--- a/frontend/src/components/fabric-editor.tsx
+++ b/frontend/src/components/fabric-editor.tsx
@@ -250,7 +250,7 @@ const QUICK_SHAPE_TITLE: Record<ShapesQuickAddKind, string> = {
 
 function toolbarIconBtn(disabled?: boolean) {
   const base =
-    'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-neutral-600 outline-none transition-colors hover:bg-black/[0.06]'
+    'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[var(--text-muted)] outline-none transition-colors hover:bg-[var(--hover)]'
   if (disabled) {
     return `${base} pointer-events-none cursor-not-allowed opacity-35`
   }
@@ -259,7 +259,7 @@ function toolbarIconBtn(disabled?: boolean) {
 
 function backgroundTopBtn(disabled?: boolean) {
   const base =
-    'flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-medium text-neutral-700 outline-none transition-colors hover:bg-black/[0.06]'
+    'flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-medium text-[var(--text)] outline-none transition-colors hover:bg-[var(--hover)]'
   if (disabled) {
     return `${base} pointer-events-none cursor-not-allowed opacity-35`
   }
@@ -3928,7 +3928,7 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
         !shapeToolbarModel &&
         canvasBodySelected ? (
           <div ref={backgroundPopoverAnchorRef} className="relative">
-            <div className="flex items-center rounded-full border border-black/[0.08] bg-white/90 px-2 py-1 shadow-[0_4px_20px_rgba(0,0,0,0.08)] backdrop-blur-md">
+            <div className="theme-toolbar-shell flex items-center rounded-full border px-2 py-1 backdrop-blur-md">
               <ArtboardResizeToolbarControl
                 width={artboardW}
                 height={artboardH}
@@ -3946,7 +3946,7 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
                 title="Background"
               >
                 <span
-                  className="h-5 w-5 shrink-0 rounded-md border border-black/15 shadow-inner"
+                  className="h-5 w-5 shrink-0 rounded-md border border-[var(--border-strong)] shadow-inner"
                   style={bgValueToSwatch(bgValue)}
                 />
                 <span className="pr-0.5">Background</span>
@@ -4035,8 +4035,8 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
                 lineHeight: 0,
                 boxShadow:
                   artboardEmptyHovered && !hasObjectSelected
-                    ? `0 4px 24px rgba(0,0,0,0.08), 0 0 0 2px ${EDITOR_CANVAS_ACCENT}`
-                    : '0 4px 24px rgba(0,0,0,0.08)',
+                    ? `var(--canvas-shell-shadow), 0 0 0 2px ${EDITOR_CANVAS_ACCENT}`
+                    : 'var(--canvas-shell-shadow)',
               }}
             >
               <canvas ref={canvasElRef} className="block max-w-none" />
@@ -4063,13 +4063,13 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex justify-center pb-2 pt-24">
         <div
           ref={bottomToolbarRef}
-          className="pointer-events-auto flex items-center gap-1 rounded-full border border-black/[0.08] bg-white/85 px-2 py-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.08),0_0_0_1px_rgba(255,255,255,0.8)_inset] backdrop-blur-xl"
+          className="theme-toolbar-shell pointer-events-auto flex items-center gap-1 rounded-full border px-2 py-1.5 backdrop-blur-xl"
           role="toolbar"
           aria-label="Editor tools"
         >
           <div
             ref={shapeToolSplitRef}
-            className="relative flex items-stretch rounded-lg border border-black/[0.06] bg-black/[0.02]"
+            className="theme-segmented relative flex items-stretch rounded-lg border"
           >
             <button
               type="button"
@@ -4088,7 +4088,7 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
             <button
               type="button"
               disabled={!ready}
-              className={`${toolbarIconBtn(!ready)} rounded-l-none rounded-r-lg border-0 border-l border-black/[0.06]`}
+              className={`${toolbarIconBtn(!ready)} rounded-l-none rounded-r-lg border-0 border-l border-[var(--line)]`}
               onClick={() => setShapesPopoverOpen((o) => !o)}
               aria-expanded={shapesPopoverOpen}
               aria-haspopup="menu"

--- a/frontend/src/components/file-grid-card.tsx
+++ b/frontend/src/components/file-grid-card.tsx
@@ -101,7 +101,7 @@ export default function FileGridCard({
   };
 
   const menuBtnClass =
-    "flex size-9 shrink-0 items-center justify-center rounded-full border border-black/[0.1] bg-white/90 text-[var(--text-muted)] opacity-0 pointer-events-none transition-[opacity,colors,border-color] duration-150 group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto hover:border-black/[0.16] hover:bg-white hover:text-[var(--text)]";
+    "flex size-9 shrink-0 items-center justify-center rounded-full border border-[var(--button-secondary-border)] bg-[var(--surface-raised)] text-[var(--text-muted)] opacity-0 pointer-events-none transition-[opacity,colors,border-color] duration-150 group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto hover:border-[var(--button-secondary-border-hover)] hover:bg-[var(--surface-overlay-strong)] hover:text-[var(--text)]";
 
   const menuBtnVisible =
     menuOpen || selected
@@ -117,7 +117,7 @@ export default function FileGridCard({
       : checkboxWrapClass;
 
   const menuItemClass =
-    "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[14px] font-medium text-[var(--text)] transition-colors hover:bg-black/[0.04]";
+    "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[14px] font-medium text-[var(--text)] transition-colors hover:bg-[var(--hover)]";
 
   const openEditorClass =
     "block no-underline text-inherit transition-colors hover:text-inherit focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--text)]";
@@ -126,7 +126,7 @@ export default function FileGridCard({
     <li className="min-w-0">
       <div
         ref={wrapRef}
-        className="group flex h-full flex-col rounded-2xl border border-[var(--line)] bg-white/50 backdrop-blur-md transition-[border-color,background-color] duration-200 hover:border-black/[0.14] hover:bg-white/72"
+        className="group flex h-full flex-col rounded-2xl border border-[var(--line)] bg-[var(--surface-soft)] backdrop-blur-md transition-[border-color,background-color] duration-200 hover:border-[var(--border-strong)] hover:bg-[var(--surface-soft-hover)]"
       >
         <div className="relative p-2.5 sm:p-3">
           <div className="absolute left-3 top-3 z-20">
@@ -140,10 +140,10 @@ export default function FileGridCard({
               />
               <span
                 className={[
-                  "flex size-[22px] items-center justify-center rounded-md border-2 bg-white/95 transition-colors",
+                  "flex size-[22px] items-center justify-center rounded-md border-2 bg-[var(--surface-overlay-strong)] transition-colors",
                   selected
                     ? "border-[var(--accent)] bg-[var(--accent)]"
-                    : "border-black/25 peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--text)] peer-focus-visible:ring-offset-2",
+                    : "border-[var(--border-strong)] peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--text)] peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-[var(--focus-ring-offset)]",
                 ].join(" ")}
                 aria-hidden
               >
@@ -152,7 +152,7 @@ export default function FileGridCard({
                     icon={Tick02Icon}
                     size={14}
                     strokeWidth={2.25}
-                    className="shrink-0 text-[#0a0a0a]"
+                    className="shrink-0 text-[#181412]"
                   />
                 ) : null}
               </span>
@@ -173,8 +173,8 @@ export default function FileGridCard({
               className={[
                 "relative aspect-[4/3] w-full overflow-hidden rounded-xl bg-[var(--surface-subtle)] transition-shadow duration-150",
                 selected
-                  ? "ring-2 ring-[var(--accent)] ring-offset-2 ring-offset-white/80"
-                  : "ring-1 ring-inset ring-black/[0.06]",
+                  ? "ring-2 ring-[var(--accent)] ring-offset-2 ring-offset-[var(--focus-ring-offset)]"
+                  : "ring-1 ring-inset ring-[var(--line)]",
               ].join(" ")}
             >
               <FileGridPreview
@@ -268,7 +268,7 @@ export default function FileGridCard({
         <Link
           to="/create"
           search={{ id: row.id }}
-          className={`${openEditorClass} flex min-h-0 flex-1 flex-col gap-2 border-t border-black/[0.05] px-4 pb-4 pt-3`}
+          className={`${openEditorClass} flex min-h-0 flex-1 flex-col gap-2 border-t border-[var(--line)] px-4 pb-4 pt-3`}
           onClick={() =>
             posthog.capture("file_opened", { file_id: row.id, method: "title" })
           }

--- a/frontend/src/components/floating-toolbar-shell.tsx
+++ b/frontend/src/components/floating-toolbar-shell.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, type ReactNode } from 'react'
 
 const shellClass =
-  'pointer-events-auto z-10 inline-flex max-w-[min(100vw-2rem,720px)] items-stretch overflow-visible rounded-full border border-black/[0.08] bg-white/90 shadow-[0_4px_20px_rgba(0,0,0,0.08)] backdrop-blur-md'
+  'theme-toolbar-shell pointer-events-auto z-10 inline-flex max-w-[min(100vw-2rem,720px)] items-stretch overflow-visible rounded-full border backdrop-blur-md'
 
 type ShellProps = {
   children: ReactNode
@@ -32,7 +32,7 @@ export function FloatingToolbarDivider() {
   return (
     <div
       className="mx-0.5 w-px shrink-0 self-center bg-black/10"
-      style={{ height: '1.25rem' }}
+      style={{ height: '1.25rem', backgroundColor: 'var(--line)' }}
       aria-hidden
     />
   )
@@ -43,13 +43,13 @@ export function floatingToolbarIconButton(
   opts?: { wide?: boolean },
 ): string {
   const base = opts?.wide
-    ? 'flex h-8 min-w-[2.75rem] shrink-0 items-center justify-center gap-0.5 rounded-lg px-1.5 text-neutral-600 outline-none transition-colors hover:bg-black/[0.06]'
-    : 'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-neutral-600 outline-none transition-colors hover:bg-black/[0.06]'
-  return active ? `${base} bg-black/[0.08] text-neutral-900` : base
+    ? 'flex h-8 min-w-[2.75rem] shrink-0 items-center justify-center gap-0.5 rounded-lg px-1.5 text-[var(--text-muted)] outline-none transition-colors hover:bg-[var(--hover)]'
+    : 'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[var(--text-muted)] outline-none transition-colors hover:bg-[var(--hover)]'
+  return active ? `${base} bg-[var(--hover-strong)] text-[var(--text)]` : base
 }
 
 const floatingToolbarPopoverSurface =
-  'z-50 rounded-xl border border-black/[0.08] bg-white shadow-[0_12px_40px_rgba(0,0,0,0.12)]'
+  'z-50 rounded-xl border border-[var(--line)] bg-[var(--surface-overlay)] shadow-[var(--shadow-floating)]'
 
 /** Use when the panel has nested flyouts; `overflow-hidden` would clip them. */
 export const floatingToolbarPopoverMenuClass = floatingToolbarPopoverSurface

--- a/frontend/src/components/new-canvas-dialog.tsx
+++ b/frontend/src/components/new-canvas-dialog.tsx
@@ -93,7 +93,7 @@ export default function NewCanvasDialog({
       }}
     >
       <div
-        className="absolute inset-0 bg-black/35 backdrop-blur-[2px]"
+        className="absolute inset-0 bg-[var(--overlay-backdrop)] backdrop-blur-[2px]"
         aria-hidden
       />
       <div
@@ -135,7 +135,7 @@ export default function NewCanvasDialog({
           </div>
         ) : (
           <>
-            <div className="mt-6 flex gap-2 rounded-full border border-black/[0.1] bg-black/[0.03] p-1">
+            <div className="theme-segmented mt-6 flex gap-2 rounded-full border p-1">
               <button
                 type="button"
                 className={[
@@ -168,7 +168,7 @@ export default function NewCanvasDialog({
                   <li key={p.id}>
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between gap-3 rounded-xl border border-transparent bg-black/[0.03] px-4 py-3 text-left transition-colors hover:border-black/[0.1] hover:bg-black/[0.05]"
+                      className="flex w-full items-center justify-between gap-3 rounded-xl border border-transparent bg-[var(--hover)] px-4 py-3 text-left transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--hover-strong)]"
                       onClick={() => goCreate(p.width, p.height, p.label)}
                     >
                       <span className="min-w-0 text-[15px] font-medium text-[var(--text)]">
@@ -197,7 +197,7 @@ export default function NewCanvasDialog({
                       inputMode="numeric"
                       value={customW}
                       onChange={(e) => setCustomW(e.target.value)}
-                      className="w-full rounded-xl border border-black/[0.12] bg-[var(--surface)] px-3 py-2.5 text-[15px] text-[var(--text)] outline-none focus:border-black/[0.22]"
+                      className="theme-input w-full rounded-xl border px-3 py-2.5 text-[15px] outline-none focus:border-[var(--button-secondary-border-hover)]"
                       autoComplete="off"
                     />
                   </div>
@@ -214,7 +214,7 @@ export default function NewCanvasDialog({
                       inputMode="numeric"
                       value={customH}
                       onChange={(e) => setCustomH(e.target.value)}
-                      className="w-full rounded-xl border border-black/[0.12] bg-[var(--surface)] px-3 py-2.5 text-[15px] text-[var(--text)] outline-none focus:border-black/[0.22]"
+                      className="theme-input w-full rounded-xl border px-3 py-2.5 text-[15px] outline-none focus:border-[var(--button-secondary-border-hover)]"
                       autoComplete="off"
                     />
                   </div>
@@ -224,7 +224,7 @@ export default function NewCanvasDialog({
                 ) : null}
                 <button
                   type="button"
-                  className="inline-flex min-h-11 w-full items-center justify-center rounded-full bg-[var(--text)] px-6 py-2.5 text-[15px] font-medium text-white hover:bg-[#262626]"
+                  className="theme-primary-button inline-flex min-h-11 w-full items-center justify-center rounded-full px-6 py-2.5 text-[15px] font-medium"
                   onClick={() => submitCustom()}
                 >
                   Create canvas
@@ -234,10 +234,10 @@ export default function NewCanvasDialog({
           </>
         )}
 
-        <div className="mt-6 flex justify-end border-t border-black/[0.06] pt-5">
+        <div className="mt-6 flex justify-end border-t border-[var(--line)] pt-5">
           <button
             type="button"
-            className="min-h-10 rounded-full bg-black/[0.05] px-5 text-[15px] font-medium text-[var(--text)] transition-colors hover:bg-black/[0.08]"
+            className="theme-secondary-button min-h-10 rounded-full border px-5 text-[15px] font-medium transition-colors"
             onClick={onClose}
           >
             {editorUnsupported ? "Close" : "Cancel"}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { Outlet, createRootRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
 import { PostHogProvider } from "posthog-js/react";
 
 import NativeTitleTooltip from "../components/native-title-tooltip";
@@ -7,7 +8,35 @@ export const Route = createRootRoute({
   component: RootLayout,
 });
 
+const THEME_STORAGE_KEY = "avnac-theme";
+
+type ThemeMode = "light" | "dark";
+
+function getPreferredTheme(): ThemeMode {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const saved = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (saved === "light" || saved === "dark") {
+    return saved;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
 function RootLayout() {
+  const [theme, setTheme] = useState<ThemeMode>(getPreferredTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+    root.style.colorScheme = theme;
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
   return (
     <PostHogProvider
       apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN!}
@@ -19,6 +48,19 @@ function RootLayout() {
         debug: import.meta.env.DEV,
       }}
     >
+      <button
+        type="button"
+        className="theme-toggle"
+        aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+        aria-pressed={theme === "dark"}
+        onClick={() =>
+          setTheme((current) => (current === "dark" ? "light" : "dark"))
+        }
+      >
+        <span className="theme-toggle-label">
+          {theme === "dark" ? "Light mode" : "Dark mode"}
+        </span>
+      </button>
       <NativeTitleTooltip />
       <Outlet />
     </PostHogProvider>

--- a/frontend/src/routes/create.tsx
+++ b/frontend/src/routes/create.tsx
@@ -93,7 +93,7 @@ function CreatePage() {
         <div className="hero-grid" aria-hidden="true" />
 
         <div className="relative z-[1] mx-auto flex w-full max-w-2xl flex-1 items-center justify-center">
-          <div className="w-full rounded-[2rem] border border-[var(--line)] bg-white/82 p-7 text-center shadow-[0_24px_80px_rgba(0,0,0,0.08)] backdrop-blur-md sm:p-10">
+          <div className="theme-glass-card w-full rounded-[2rem] border p-7 text-center backdrop-blur-md sm:p-10">
             <div className="landing-kicker mb-3">Desktop Only</div>
             <h1 className="display-title text-[clamp(2rem,8vw,3rem)] font-medium leading-[1.04] tracking-[-0.03em] text-[var(--text)]">
               The editor is not available on mobile.
@@ -105,13 +105,13 @@ function CreatePage() {
             <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
               <Link
                 to="/files"
-                className="inline-flex min-h-12 items-center justify-center rounded-full border-0 bg-[var(--text)] px-8 py-3 text-base font-medium text-white no-underline hover:bg-[#262626]"
+                className="theme-primary-button inline-flex min-h-12 items-center justify-center rounded-full border-0 px-8 py-3 text-base font-medium no-underline"
               >
                 Go to files
               </Link>
               <Link
                 to="/"
-                className="inline-flex min-h-12 items-center justify-center rounded-full border border-black/[0.14] bg-white/70 px-8 py-3 text-base font-medium text-[var(--text)] no-underline hover:border-black/[0.22] hover:bg-white"
+                className="theme-secondary-button inline-flex min-h-12 items-center justify-center rounded-full border px-8 py-3 text-base font-medium text-[var(--text)] no-underline"
               >
                 Back home
               </Link>

--- a/frontend/src/routes/files.tsx
+++ b/frontend/src/routes/files.tsx
@@ -163,7 +163,7 @@ function FilesPage() {
           <div className="mx-auto flex w-full max-w-6xl justify-end px-5 sm:px-8 pointer-events-auto">
             <button
               type="button"
-              className="inline-flex min-h-11 shrink-0 cursor-pointer items-center justify-center rounded-full border-0 bg-[var(--text)] px-6 py-2.5 text-[15px] font-medium text-white transition hover:bg-[#262626] sm:min-h-12 sm:px-8 sm:py-3 sm:text-[1.0625rem]"
+              className="theme-primary-button inline-flex min-h-11 shrink-0 cursor-pointer items-center justify-center rounded-full border-0 px-6 py-2.5 text-[15px] font-medium transition sm:min-h-12 sm:px-8 sm:py-3 sm:text-[1.0625rem]"
               onClick={() => setNewCanvasOpen(true)}
             >
               New file
@@ -201,7 +201,7 @@ function FilesPage() {
                 </p>
                 <button
                   type="button"
-                  className="mt-8 inline-flex min-h-12 cursor-pointer items-center justify-center rounded-full border-0 bg-[var(--text)] px-10 py-3.5 text-base font-medium text-white hover:bg-[#262626] sm:min-h-14 sm:px-12 sm:py-4 sm:text-[1.0625rem]"
+                  className="theme-primary-button mt-8 inline-flex min-h-12 cursor-pointer items-center justify-center rounded-full border-0 px-10 py-3.5 text-base font-medium sm:min-h-14 sm:px-12 sm:py-4 sm:text-[1.0625rem]"
                   onClick={() => setNewCanvasOpen(true)}
                 >
                   Open editor

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -451,7 +451,7 @@ function Landing() {
             <div className="flex flex-wrap items-center gap-4">
               <button
                 type="button"
-                className="bg-black text-white inline-flex min-h-12 cursor-pointer items-center justify-center rounded-full border-0 px-10 py-3.5 text-base font-medium sm:min-h-14 sm:px-12 sm:py-4 sm:text-[1.0625rem]"
+                className="theme-primary-button inline-flex min-h-12 cursor-pointer items-center justify-center rounded-full border-0 px-10 py-3.5 text-base font-medium sm:min-h-14 sm:px-12 sm:py-4 sm:text-[1.0625rem]"
                 onClick={openEditor}
               >
                 {primaryCtaLabel}
@@ -460,7 +460,7 @@ function Landing() {
                 href="https://github.com/akinloluwami/avnac"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex min-h-12 items-center justify-center rounded-full border border-black/[0.14] bg-white/70 px-8 py-3.5 text-base font-medium text-[var(--text)] no-underline backdrop-blur-sm hover:border-black/[0.22] hover:bg-white sm:min-h-14 sm:px-10 sm:py-4 sm:text-[1.0625rem]"
+                className="theme-secondary-button inline-flex min-h-12 items-center justify-center rounded-full border px-8 py-3.5 text-base font-medium text-[var(--text)] no-underline backdrop-blur-sm sm:min-h-14 sm:px-10 sm:py-4 sm:text-[1.0625rem]"
               >
                 GitHub
               </a>
@@ -616,7 +616,7 @@ function Landing() {
             <div className="landing-cta-actions">
               <button
                 type="button"
-                className="bg-black text-white min-h-12 cursor-pointer items-center justify-center rounded-full border-0 px-10 py-3.5 text-base font-medium sm:min-h-14 sm:px-12 sm:py-4 sm:text-[1.0625rem]"
+                className="theme-primary-button min-h-12 cursor-pointer items-center justify-center rounded-full border-0 px-10 py-3.5 text-base font-medium sm:min-h-14 sm:px-12 sm:py-4 sm:text-[1.0625rem]"
                 onClick={openEditor}
               >
                 {primaryCtaLabel}
@@ -625,7 +625,7 @@ function Landing() {
                 href="https://github.com/akinloluwami/avnac"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex min-h-12 items-center justify-center rounded-full border border-black/[0.14] bg-white/85 px-8 py-3.5 text-base font-medium text-[var(--text)] no-underline hover:border-black/[0.22] hover:bg-white sm:min-h-14 sm:px-10 sm:py-4 sm:text-[1.0625rem]"
+                className="theme-secondary-button inline-flex min-h-12 items-center justify-center rounded-full border px-8 py-3.5 text-base font-medium text-[var(--text)] no-underline sm:min-h-14 sm:px-10 sm:py-4 sm:text-[1.0625rem]"
               >
                 View source
               </a>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,11 +12,34 @@
     --text-muted: #525252;
     --text-subtle: #737373;
     --border: rgba(0, 0, 0, 0.08);
+    --border-strong: rgba(0, 0, 0, 0.14);
     --surface: #ffffff;
     --surface-subtle: #fafafa;
+    --surface-soft: rgba(255, 255, 255, 0.82);
+    --surface-soft-hover: rgba(255, 255, 255, 0.92);
+    --surface-raised: rgba(255, 255, 255, 0.9);
+    --surface-overlay: rgba(255, 255, 255, 0.95);
+    --surface-overlay-strong: #ffffff;
+    --surface-panel: rgba(245, 245, 245, 0.95);
+    --surface-input: #ffffff;
     --hover: #f5f5f5;
+    --hover-strong: rgba(0, 0, 0, 0.06);
     --link: #0a0a0a;
     --link-hover: #404040;
+    --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.04);
+    --shadow-panel: 0 18px 50px rgba(15, 23, 42, 0.08);
+    --shadow-floating: 0 12px 40px rgba(0, 0, 0, 0.12);
+    --overlay-backdrop: rgba(10, 10, 10, 0.35);
+    --canvas-shell-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+    --toolbar-inset: rgba(255, 255, 255, 0.8);
+    --button-primary: #171717;
+    --button-primary-hover: #262626;
+    --button-primary-text: #fafafa;
+    --button-secondary-bg: rgba(255, 255, 255, 0.74);
+    --button-secondary-bg-hover: rgba(255, 255, 255, 0.92);
+    --button-secondary-border: rgba(0, 0, 0, 0.14);
+    --button-secondary-border-hover: rgba(0, 0, 0, 0.22);
+    --focus-ring-offset: #ffffff;
 
     --sea-ink: var(--text);
     --sea-ink-soft: var(--text-muted);
@@ -35,6 +58,45 @@
 
     /* Single knob for canvas/editor accent (selection chrome, guides, focus rings, etc.) */
     --accent: #ffb88e;
+  }
+
+  :root[data-theme="dark"] {
+    --text: #e7e5e4;
+    --text-muted: #b8b1aa;
+    --text-subtle: #958d86;
+    --border: rgba(255, 255, 255, 0.09);
+    --border-strong: rgba(255, 255, 255, 0.16);
+    --surface: #1a1816;
+    --surface-subtle: #12100f;
+    --surface-soft: rgba(34, 30, 28, 0.84);
+    --surface-soft-hover: rgba(43, 38, 35, 0.92);
+    --surface-raised: rgba(33, 29, 27, 0.92);
+    --surface-overlay: rgba(28, 25, 23, 0.95);
+    --surface-overlay-strong: #211d1b;
+    --surface-panel: rgba(28, 25, 23, 0.95);
+    --surface-input: #221f1d;
+    --hover: rgba(255, 255, 255, 0.06);
+    --hover-strong: rgba(255, 255, 255, 0.08);
+    --link: #f5efe8;
+    --link-hover: #ffe0cb;
+    --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow-panel: 0 18px 50px rgba(0, 0, 0, 0.28);
+    --shadow-floating: 0 12px 40px rgba(0, 0, 0, 0.32);
+    --overlay-backdrop: rgba(0, 0, 0, 0.46);
+    --canvas-shell-shadow: 0 4px 24px rgba(0, 0, 0, 0.34);
+    --toolbar-inset: rgba(255, 255, 255, 0.05);
+    --button-primary: #f0ebe6;
+    --button-primary-hover: #fff6ef;
+    --button-primary-text: #181412;
+    --button-secondary-bg: rgba(36, 32, 30, 0.86);
+    --button-secondary-bg-hover: rgba(48, 43, 40, 0.94);
+    --button-secondary-border: rgba(255, 255, 255, 0.14);
+    --button-secondary-border-hover: rgba(255, 255, 255, 0.22);
+    --focus-ring-offset: #1a1816;
+    --header-bg: rgba(26, 24, 22, 0.92);
+    --inset-glint: rgba(255, 255, 255, 0.04);
+    --default-object-fill: #f0ebe6;
+    --accent: #efb38a;
   }
 
   *,
@@ -94,7 +156,7 @@
   .island-shell {
     border: 1px solid var(--border);
     background: var(--surface);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    box-shadow: var(--shadow-soft);
   }
 
   button,
@@ -145,6 +207,26 @@
       linear-gradient(180deg, #f6f6f4 0%, #ececea 100%);
   }
 
+  :root[data-theme="dark"] .hero-page {
+    background:
+      radial-gradient(
+        ellipse 70% 50% at 12% 0%,
+        rgba(112, 84, 109, 0.16),
+        transparent 60%
+      ),
+      radial-gradient(
+        ellipse 70% 50% at 92% 100%,
+        rgba(151, 114, 88, 0.12),
+        transparent 62%
+      ),
+      radial-gradient(
+        ellipse 85% 55% at 50% -15%,
+        rgba(255, 255, 255, 0.02),
+        transparent 46%
+      ),
+      linear-gradient(180deg, #141210 0%, #0f0d0c 100%);
+  }
+
   .hero-grid {
     position: absolute;
     inset: 0;
@@ -160,12 +242,24 @@
     pointer-events: none;
   }
 
+  :root[data-theme="dark"] .hero-grid {
+    background-image:
+      linear-gradient(rgba(12, 10, 9, 0.38), rgba(12, 10, 9, 0.38)),
+      linear-gradient(to right, rgba(255, 255, 255, 0.028) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.028) 1px, transparent 1px);
+  }
+
   .hero-bg-orb {
     position: absolute;
     border-radius: 999px;
     filter: blur(72px);
     opacity: 0.55;
     pointer-events: none;
+  }
+
+  :root[data-theme="dark"] .hero-bg-orb {
+    opacity: 0.28;
+    filter: blur(88px);
   }
 
   .hero-bg-orb-a {
@@ -192,6 +286,22 @@
     );
   }
 
+  :root[data-theme="dark"] .hero-bg-orb-a {
+    background: radial-gradient(
+      circle at 40% 40%,
+      rgba(146, 103, 141, 0.34),
+      rgba(146, 103, 141, 0) 62%
+    );
+  }
+
+  :root[data-theme="dark"] .hero-bg-orb-b {
+    background: radial-gradient(
+      circle at 35% 35%,
+      rgba(160, 129, 103, 0.22),
+      rgba(160, 129, 103, 0) 60%
+    );
+  }
+
   .landing-page {
     background:
       radial-gradient(
@@ -200,6 +310,12 @@
         transparent 28%
       ),
       linear-gradient(180deg, #efeeea 0%, #f7f4ee 36%, #fffdf8 100%);
+  }
+
+  :root[data-theme="dark"] .landing-page {
+    background:
+      radial-gradient(circle at top, rgba(255, 255, 255, 0.06), transparent 28%),
+      linear-gradient(180deg, #151210 0%, #12100f 36%, #0f0d0c 100%);
   }
 
   .landing-section {
@@ -241,6 +357,12 @@
     color: var(--text-subtle);
   }
 
+  :root[data-theme="dark"] .landing-kicker {
+    border-color: rgba(255, 255, 255, 0.1);
+    background: rgba(31, 27, 25, 0.72);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
+  }
+
   .landing-primary-button {
     position: relative;
     color: var(--text);
@@ -267,6 +389,13 @@
     box-shadow:
       0 8px 20px rgba(246, 213, 247, 0.1),
       0 1px 0 rgba(255, 255, 255, 0.72) inset;
+  }
+
+  :root[data-theme="dark"] .landing-kicker-inverse {
+    border-color: rgba(255, 255, 255, 0.09);
+    background: rgba(35, 31, 29, 0.72);
+    color: #d9cbc0;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
   }
 
   .landing-section-title,
@@ -321,6 +450,17 @@
     padding: 1rem;
   }
 
+  :root[data-theme="dark"] .landing-feature-window {
+    border-color: rgba(255, 255, 255, 0.08);
+    background:
+      radial-gradient(circle at top left, rgba(255, 205, 112, 0.08), transparent 34%),
+      radial-gradient(circle at bottom right, rgba(255, 184, 142, 0.12), transparent 36%),
+      linear-gradient(180deg, #201c1a 0%, #171412 100%);
+    box-shadow:
+      0 25px 65px rgba(0, 0, 0, 0.24),
+      0 1px 0 rgba(255, 255, 255, 0.05) inset;
+  }
+
   .landing-feature-toolbar {
     display: flex;
     gap: 0.45rem;
@@ -332,6 +472,10 @@
     height: 0.7rem;
     border-radius: 999px;
     background: rgba(10, 10, 10, 0.14);
+  }
+
+  :root[data-theme="dark"] .landing-feature-toolbar span {
+    background: rgba(255, 255, 255, 0.18);
   }
 
   .landing-feature-canvas {
@@ -350,6 +494,14 @@
     padding: 1.2rem;
   }
 
+  :root[data-theme="dark"] .landing-feature-canvas {
+    border-color: rgba(255, 255, 255, 0.08);
+    background:
+      linear-gradient(rgba(28, 24, 22, 0.9), rgba(28, 24, 22, 0.9)),
+      linear-gradient(to right, rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  }
+
   .landing-feature-card {
     position: absolute;
     display: grid;
@@ -360,6 +512,12 @@
     background: rgba(255, 255, 255, 0.86);
     box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
     padding: 1rem;
+  }
+
+  :root[data-theme="dark"] .landing-feature-card {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(29, 26, 24, 0.88);
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.24);
   }
 
   .landing-feature-card strong {
@@ -386,6 +544,10 @@
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--text-subtle);
+  }
+
+  :root[data-theme="dark"] .landing-feature-chip {
+    background: rgba(255, 255, 255, 0.07);
   }
 
   .landing-feature-card-a {
@@ -417,6 +579,12 @@
     background: rgba(255, 255, 255, 0.72);
     box-shadow: 0 18px 50px rgba(15, 23, 42, 0.05);
     padding: 1.35rem;
+  }
+
+  :root[data-theme="dark"] .landing-copy-card {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(27, 24, 22, 0.76);
+    box-shadow: 0 18px 50px rgba(0, 0, 0, 0.18);
   }
 
   .landing-copy-card h3 {
@@ -460,6 +628,18 @@
     padding: 1.5rem;
   }
 
+  :root[data-theme="dark"] .landing-process-shell {
+    background:
+      radial-gradient(circle at top left, rgba(246, 213, 247, 0.1), transparent 28%),
+      radial-gradient(circle at 86% 18%, rgba(255, 225, 147, 0.08), transparent 24%),
+      radial-gradient(circle at bottom right, rgba(255, 184, 142, 0.08), transparent 26%),
+      linear-gradient(180deg, #1a1715 0%, #141210 100%);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 24px 60px rgba(0, 0, 0, 0.2),
+      0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  }
+
   .landing-process-header {
     display: grid;
     gap: 1rem;
@@ -494,6 +674,14 @@
       0 12px 30px rgba(15, 23, 42, 0.04),
       0 1px 0 rgba(255, 255, 255, 0.72) inset;
     padding: 1.25rem;
+  }
+
+  :root[data-theme="dark"] .landing-process-card {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(31, 27, 25, 0.78);
+    box-shadow:
+      0 12px 30px rgba(0, 0, 0, 0.18),
+      0 1px 0 rgba(255, 255, 255, 0.04) inset;
   }
 
   .landing-process-card span {
@@ -542,6 +730,17 @@
       0 20px 48px rgba(15, 23, 42, 0.05),
       0 1px 0 rgba(255, 255, 255, 0.74) inset;
     padding: 1.5rem;
+  }
+
+  :root[data-theme="dark"] .landing-ai-shell {
+    border-color: rgba(255, 255, 255, 0.08);
+    background:
+      radial-gradient(circle at top left, rgba(246, 213, 247, 0.08), transparent 24%),
+      radial-gradient(circle at 88% 14%, rgba(255, 225, 147, 0.07), transparent 18%),
+      linear-gradient(180deg, rgba(28, 24, 22, 0.9), rgba(21, 18, 16, 0.88));
+    box-shadow:
+      0 20px 48px rgba(0, 0, 0, 0.18),
+      0 1px 0 rgba(255, 255, 255, 0.04) inset;
   }
 
   .landing-ai-shell::before {
@@ -611,6 +810,14 @@
     padding: 1.2rem;
   }
 
+  :root[data-theme="dark"] .landing-ai-hero-card {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(30, 27, 25, 0.84);
+    box-shadow:
+      0 14px 36px rgba(0, 0, 0, 0.18),
+      0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  }
+
   .landing-ai-hero-label {
     display: inline-flex;
     border-radius: 999px;
@@ -647,6 +854,11 @@
     color: var(--text-muted);
   }
 
+  :root[data-theme="dark"] .landing-ai-prompt-list span {
+    border-color: rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
   .landing-ai-card-list {
     display: grid;
     gap: 1rem;
@@ -658,6 +870,12 @@
     background: rgba(255, 255, 255, 0.76);
     box-shadow: 0 12px 28px rgba(15, 23, 42, 0.04);
     padding: 1.1rem;
+  }
+
+  :root[data-theme="dark"] .landing-ai-card {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(31, 28, 26, 0.76);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
   }
 
   .landing-ai-card h3 {
@@ -694,6 +912,14 @@
       );
     box-shadow: 0 24px 60px rgba(15, 23, 42, 0.06);
     padding: 1.6rem;
+  }
+
+  :root[data-theme="dark"] .landing-cta-band {
+    border-color: rgba(255, 255, 255, 0.08);
+    background:
+      radial-gradient(circle at top right, rgba(255, 225, 147, 0.12), transparent 28%),
+      linear-gradient(180deg, rgba(31, 27, 25, 0.82), rgba(24, 21, 19, 0.72));
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.2);
   }
 
   .landing-cta-band-only {
@@ -748,6 +974,14 @@
       box-shadow 160ms ease;
   }
 
+  :root[data-theme="dark"] .hero-sticker-selection {
+    border-color: rgba(255, 255, 255, 0.28);
+    background:
+      linear-gradient(rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.03)),
+      linear-gradient(to right, rgba(255, 255, 255, 0.07) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.07) 1px, transparent 1px);
+  }
+
   .hero-sticker-frame:hover .hero-sticker-selection,
   .hero-sticker-frame.is-active .hero-sticker-selection {
     border-color: var(--accent);
@@ -765,6 +999,13 @@
     box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
     opacity: 0.96;
     transition: border-color 160ms ease;
+  }
+
+  :root[data-theme="dark"] .hero-sticker-handle,
+  :root[data-theme="dark"] .hero-sticker-rotation-handle {
+    border-color: rgba(255, 255, 255, 0.28);
+    background: #2b2623;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22);
   }
 
   .hero-sticker-frame:hover .hero-sticker-handle,
@@ -980,6 +1221,111 @@
       0 0 0 1px rgba(139, 61, 255, 0.12) inset;
   }
 
+  :root[data-theme="dark"] .avnac-ai-tile {
+    background: linear-gradient(135deg, #2b2624 0%, #2e2634 55%, #33283b 100%);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.2),
+      0 0 0 1px rgba(139, 61, 255, 0.22) inset;
+  }
+
+  :root[data-theme="dark"] .avnac-ai-tile:hover {
+    background: linear-gradient(135deg, #312b29 0%, #372d3f 55%, #3d2f48 100%);
+    box-shadow:
+      0 2px 8px rgba(139, 61, 255, 0.18),
+      0 0 0 1px rgba(139, 61, 255, 0.28) inset;
+  }
+
+  :root[data-theme="dark"] .avnac-ai-tile[aria-pressed="true"] {
+    background: linear-gradient(135deg, #352f2d 0%, #3e3148 55%, #473453 100%);
+    box-shadow:
+      0 2px 10px rgba(139, 61, 255, 0.22),
+      0 0 0 1px rgba(139, 61, 255, 0.34) inset;
+  }
+
+  .theme-toggle {
+    position: fixed;
+    left: 1rem;
+    bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+    z-index: 300;
+    display: inline-flex;
+    min-height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 0.9rem;
+    border: 1px solid var(--button-secondary-border);
+    border-radius: 999px;
+    background: var(--surface-overlay);
+    color: var(--text);
+    box-shadow: var(--shadow-floating);
+    backdrop-filter: blur(14px);
+  }
+
+  .theme-toggle:hover {
+    background: var(--surface-overlay-strong);
+    border-color: var(--button-secondary-border-hover);
+  }
+
+  .theme-toggle-label {
+    font-size: 0.84rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+
+  .theme-primary-button {
+    color: var(--button-primary-text);
+    background: var(--button-primary);
+  }
+
+  .theme-primary-button:hover {
+    background: var(--button-primary-hover);
+  }
+
+  .theme-secondary-button {
+    color: var(--text);
+    border-color: var(--button-secondary-border);
+    background: var(--button-secondary-bg);
+  }
+
+  .theme-secondary-button:hover {
+    border-color: var(--button-secondary-border-hover);
+    background: var(--button-secondary-bg-hover);
+  }
+
+  .theme-glass-card {
+    border-color: var(--border);
+    background: var(--surface-soft);
+    box-shadow: var(--shadow-panel);
+  }
+
+  .theme-sidebar-panel {
+    border-color: var(--border);
+    background: var(--surface-overlay);
+    box-shadow: var(--shadow-floating);
+  }
+
+  .theme-toolbar-shell {
+    border-color: var(--border);
+    background: var(--surface-raised);
+    box-shadow:
+      0 8px 30px rgba(0, 0, 0, 0.12),
+      0 0 0 1px var(--toolbar-inset) inset;
+  }
+
+  .theme-segmented {
+    border-color: var(--border);
+    background: var(--hover);
+  }
+
+  .theme-input {
+    border-color: var(--border-strong);
+    background: var(--surface-input);
+    color: var(--text);
+  }
+
+  .theme-input::placeholder {
+    color: var(--text-subtle);
+  }
+
   .avnac-ai-tile:hover {
     background: linear-gradient(135deg, #f7f5f2 0%, #ece5f5 55%, #ddcaf0 100%);
     box-shadow:
@@ -1059,10 +1405,18 @@
     color: var(--text-muted);
   }
 
+  :root[data-theme="dark"] .avnac-chat-md blockquote {
+    border-left-color: rgba(255, 255, 255, 0.16);
+  }
+
   .avnac-chat-md hr {
     margin: 0.75em 0;
     border: 0;
     border-top: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  :root[data-theme="dark"] .avnac-chat-md hr {
+    border-top-color: rgba(255, 255, 255, 0.08);
   }
 
   .avnac-chat-md table {
@@ -1075,5 +1429,10 @@
   .avnac-chat-md td {
     border: 1px solid rgba(0, 0, 0, 0.1);
     padding: 0.25em 0.45em;
+  }
+
+  :root[data-theme="dark"] .avnac-chat-md th,
+  :root[data-theme="dark"] .avnac-chat-md td {
+    border-color: rgba(255, 255, 255, 0.1);
   }
 }


### PR DESCRIPTION
## Summary

Adds dark mode to the frontend with a persistent theme toggle and updates the main app surfaces so the experience stays readable and visually consistent across pages and editor chrome.

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d1ee45ed-4e3c-4a0a-a72f-cd5af18ae46c" />


## What’s included

- Added a global dark mode toggle with persisted theme selection
- Introduced shared theme tokens in the global stylesheet for text, surfaces, borders, hover states, and overlays
- Applied dark mode to the main routes:
  - Landing page
  - Files page
  - Create/editor entry flow
- Updated editor chrome to support dark mode:
  - Floating sidebar
  - Floating toolbars and popovers
  - Export menu
  - Canvas zoom slider
  - Range slider styling
  - Artboard resize controls
- Updated sidebar panels to support dark mode:
  - Layers
  - Uploads
  - Images
  - Vector boards
  - Apps
  - Magic/AI
- Updated dialogs and cards for dark mode:
  - New canvas dialog
  - Delete confirmation dialog
  - File grid cards
- Tuned contrast in dark mode for:
  - Slider knob visibility
  - Artboard size controls and labels
  - Sidebar popup text and controls
  - Files page background glow/gradient intensity

## Notes

- The work focuses on keeping contrast readable without making the dark theme overly harsh.
- `package-lock.json` was also updated in this commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Dark Mode across the app with a persistent theme toggle and expanded design tokens. Pages and editor chrome now use theme classes for consistent contrast; the editor also supports clipboard image paste and a canvas context menu.

- **New Features**
  - Theme toggle persists via `localStorage` (`avnac-theme`) and respects system preference on first load.
  - Expanded tokens in `styles.css` (text, surfaces, borders, hover, overlays, shadows, buttons, inputs) and applied across Landing, Files, Create/editor flow, editor chrome, side panels, dialogs, and cards.
  - Editor: paste images from clipboard and use a canvas context menu.
  - Added MIT `LICENSE`.

- **Refactors**
  - Replaced hard-coded colors with variables and utility classes: `theme-toolbar-shell`, `theme-sidebar-panel`, `theme-primary-button`, `theme-secondary-button`, `theme-input`, `theme-glass-card`, `theme-segmented`.
  - Unified borders/overlays and text tokens (e.g., `var(--line)`, `var(--overlay-backdrop)`, `var(--text)`, `var(--text-muted)`); tuned contrast for sliders, artboard controls, sidebar text, and Files background.
  - Theme state managed in `__root.tsx` by setting `data-theme` and `color-scheme`.

<sup>Written for commit 8e91aeb8d5b37e045747b751b58106886fb29d68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

