### PR TITLE
Enhance editor with svg and jpg export, undo and redo buttons and color picker modal

### DIFF
--- a/frontend/src/components/background-popover.tsx
+++ b/frontend/src/components/background-popover.tsx
@@ -296,7 +296,6 @@ function SolidColorRectPicker({ value, onChange }: SolidColorRectPickerProps) {
     [hsv.s, hsv.v, onChange],
   )
 
-  const safeHex = HEX6.test(value) ? value : '#ffffff'
   const hueForBg = Math.round(hsv.h)
 
   return (

--- a/frontend/src/components/background-popover.tsx
+++ b/frontend/src/components/background-popover.tsx
@@ -172,8 +172,6 @@ function clampAngle(n: number): number {
 type RgbColor = { r: number; g: number; b: number }
 type HsvColor = { h: number; s: number; v: number }
 
-const COLOR_WHEEL_SIZE = 168
-
 function clamp01(n: number): number {
   if (!Number.isFinite(n)) return 0
   return Math.min(1, Math.max(0, n))
@@ -263,125 +261,129 @@ function hexToHsv(hex: string): HsvColor | null {
   return rgbToHsv(rgb)
 }
 
-function colorWheelMarker(hsv: HsvColor): { left: number; top: number } {
-  const radius = COLOR_WHEEL_SIZE / 2
-  const theta = (hsv.h * Math.PI) / 180
-  const dist = clamp01(hsv.s) * radius
-  return {
-    left: radius + Math.cos(theta) * dist,
-    top: radius + Math.sin(theta) * dist,
-  }
-}
-
-type SolidColorWheelProps = {
+type SolidColorRectPickerProps = {
   value: string
   onChange: (hex: string) => void
 }
 
-function SolidColorWheel({ value, onChange }: SolidColorWheelProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [dragging, setDragging] = useState(false)
+function SolidColorRectPicker({ value, onChange }: SolidColorRectPickerProps) {
+  const svRef = useRef<HTMLDivElement>(null)
+  const hueRef = useRef<HTMLDivElement>(null)
+  const [svDragging, setSvDragging] = useState(false)
+  const [hueDragging, setHueDragging] = useState(false)
   const hsv = useMemo(() => hexToHsv(value) ?? { h: 0, s: 0, v: 1 }, [value])
 
-  const drawWheel = useCallback(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    const size = COLOR_WHEEL_SIZE
-    const radius = size / 2
-    canvas.width = size
-    canvas.height = size
-
-    const img = ctx.createImageData(size, size)
-    for (let y = 0; y < size; y += 1) {
-      for (let x = 0; x < size; x += 1) {
-        const dx = x - radius
-        const dy = y - radius
-        const dist = Math.hypot(dx, dy)
-        const idx = (y * size + x) * 4
-        if (dist > radius) {
-          img.data[idx + 3] = 0
-          continue
-        }
-        const h = ((Math.atan2(dy, dx) * 180) / Math.PI + 360) % 360
-        const s = dist / radius
-        const rgb = hsvToRgb({ h, s, v: 1 })
-        img.data[idx] = rgb.r
-        img.data[idx + 1] = rgb.g
-        img.data[idx + 2] = rgb.b
-        img.data[idx + 3] = 255
-      }
-    }
-    ctx.putImageData(img, 0, 0)
-  }, [])
-
-  useEffect(() => {
-    drawWheel()
-  }, [drawWheel])
-
-  const updateFromPointer = useCallback(
+  const updateFromSvPointer = useCallback(
     (clientX: number, clientY: number) => {
-      const canvas = canvasRef.current
-      if (!canvas) return
-      const rect = canvas.getBoundingClientRect()
-      const radius = COLOR_WHEEL_SIZE / 2
-      let dx = clientX - rect.left - radius
-      let dy = clientY - rect.top - radius
-      let dist = Math.hypot(dx, dy)
-      if (dist > radius) {
-        dx = (dx / dist) * radius
-        dy = (dy / dist) * radius
-        dist = radius
-      }
-      const h = ((Math.atan2(dy, dx) * 180) / Math.PI + 360) % 360
-      const s = clamp01(dist / radius)
-      onChange(rgbToHex(hsvToRgb({ h, s, v: 1 })))
+      const el = svRef.current
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      const s = clamp01((clientX - rect.left) / rect.width)
+      const v = clamp01(1 - (clientY - rect.top) / rect.height)
+      onChange(rgbToHex(hsvToRgb({ h: hsv.h, s, v })))
     },
-    [onChange],
+    [hsv.h, onChange],
   )
 
-  const marker = colorWheelMarker(hsv)
+  const updateFromHuePointer = useCallback(
+    (clientX: number) => {
+      const el = hueRef.current
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      const h = clamp01((clientX - rect.left) / rect.width) * 360
+      onChange(rgbToHex(hsvToRgb({ h, s: hsv.s, v: hsv.v })))
+    },
+    [hsv.s, hsv.v, onChange],
+  )
+
+  const safeHex = HEX6.test(value) ? value : '#ffffff'
+  const hueForBg = Math.round(hsv.h)
 
   return (
-    <div className="relative h-[168px] w-[168px]">
-      <canvas
-        ref={canvasRef}
-        className="h-full w-full rounded-full border border-black/15 shadow-[inset_0_1px_8px_rgba(0,0,0,0.1)]"
+    <div className="space-y-3">
+     
+
+      <div
+        ref={svRef}
+        className="relative h-32 w-full rounded-md border border-black/15"
+        style={{
+          backgroundImage: `linear-gradient(to top, #000 0%, rgba(0,0,0,0) 100%), linear-gradient(to right, #fff 0%, hsl(${hueForBg} 100% 50%) 100%)`,
+        }}
         onPointerDown={(e) => {
           e.preventDefault()
           e.currentTarget.setPointerCapture(e.pointerId)
-          setDragging(true)
-          updateFromPointer(e.clientX, e.clientY)
+          setSvDragging(true)
+          updateFromSvPointer(e.clientX, e.clientY)
         }}
         onPointerMove={(e) => {
-          if (!dragging) return
-          updateFromPointer(e.clientX, e.clientY)
+          if (!svDragging) return
+          updateFromSvPointer(e.clientX, e.clientY)
         }}
         onPointerUp={(e) => {
           if (e.currentTarget.hasPointerCapture(e.pointerId)) {
             e.currentTarget.releasePointerCapture(e.pointerId)
           }
-          setDragging(false)
+          setSvDragging(false)
         }}
         onPointerCancel={(e) => {
           if (e.currentTarget.hasPointerCapture(e.pointerId)) {
             e.currentTarget.releasePointerCapture(e.pointerId)
           }
-          setDragging(false)
+          setSvDragging(false)
         }}
-        aria-label="Color wheel"
-      />
-      <span
-        className="pointer-events-none absolute z-[1] h-3.5 w-3.5 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.45)]"
+        aria-label="Saturation and brightness"
+      >
+        <span
+          className="pointer-events-none absolute z-[1] h-3.5 w-3.5 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.45)]"
+          style={{
+            left: `${hsv.s * 100}%`,
+            top: `${(1 - hsv.v) * 100}%`,
+            transform: 'translate(-50%, -50%)',
+          }}
+          aria-hidden
+        />
+      </div>
+
+      <div
+        ref={hueRef}
+        className="relative h-3 w-full rounded-full border border-black/15"
         style={{
-          left: marker.left,
-          top: marker.top,
-          transform: 'translate(-50%, -50%)',
+          background:
+            'linear-gradient(to right, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%)',
         }}
-        aria-hidden
-      />
+        onPointerDown={(e) => {
+          e.preventDefault()
+          e.currentTarget.setPointerCapture(e.pointerId)
+          setHueDragging(true)
+          updateFromHuePointer(e.clientX)
+        }}
+        onPointerMove={(e) => {
+          if (!hueDragging) return
+          updateFromHuePointer(e.clientX)
+        }}
+        onPointerUp={(e) => {
+          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.currentTarget.releasePointerCapture(e.pointerId)
+          }
+          setHueDragging(false)
+        }}
+        onPointerCancel={(e) => {
+          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.currentTarget.releasePointerCapture(e.pointerId)
+          }
+          setHueDragging(false)
+        }}
+        aria-label="Hue"
+      >
+        <span
+          className="pointer-events-none absolute top-1/2 z-[1] h-4 w-4 rounded-full border-2 border-white bg-transparent shadow-[0_0_0_1px_rgba(0,0,0,0.45)]"
+          style={{
+            left: `${(hsv.h / 360) * 100}%`,
+            transform: 'translate(-50%, -50%)',
+          }}
+          aria-hidden
+        />
+      </div>
     </div>
   )
 }
@@ -411,6 +413,7 @@ export default function BackgroundPopover({
   onChange,
 }: Props) {
   const [tab, setTab] = useState<Tab>(value.type === 'gradient' ? 'gradient' : 'solid')
+  const [showSolidPicker, setShowSolidPicker] = useState(false)
   const customColorRef = useRef<HTMLInputElement>(null)
   const gradColor1Ref = useRef<HTMLInputElement>(null)
   const gradColor2Ref = useRef<HTMLInputElement>(null)
@@ -440,6 +443,19 @@ export default function BackgroundPopover({
       setGradStop2(value.stops[1]?.color ?? '#764ba2')
     }
   }, [value])
+
+  useEffect(() => {
+    if (tab !== 'solid') setShowSolidPicker(false)
+  }, [tab])
+
+  useEffect(() => {
+    if (!showSolidPicker) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowSolidPicker(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [showSolidPicker])
 
   function applySolid(hex: string) {
     setCustomColor(hex)
@@ -503,6 +519,32 @@ export default function BackgroundPopover({
       {tab === 'solid' ? (
         <div>
           <div className="mb-2.5 grid grid-cols-6 gap-2 justify-items-center">
+            <button
+              type="button"
+              className={`relative h-12 w-12 shrink-0 rounded-full border transition-shadow ${
+                showSolidPicker
+                  ? 'border-neutral-900 ring-2 ring-neutral-900/20'
+                  : 'border-black/10 hover:border-black/25'
+              }`}
+              style={{
+                background:
+                  'conic-gradient(from 0deg, #ff3b30, #ffcc00, #34c759, #32ade6, #5856d6, #ff2d55, #ff3b30)',
+              }}
+              onClick={() => setShowSolidPicker((v) => !v)}
+              aria-label="Open color picker"
+              title="Open color picker"
+            >
+              <span
+                className="pointer-events-none absolute inset-2 rounded-full border border-white/70"
+                style={{
+                  backgroundColor:
+                    value.type === 'solid' && HEX6.test(value.color)
+                      ? value.color
+                      : '#ffffff',
+                }}
+                aria-hidden
+              />
+            </button>
             {PRESET_SOLIDS.map((hex) => (
               <button
                 key={hex}
@@ -523,18 +565,6 @@ export default function BackgroundPopover({
                 title={hex === 'transparent' ? 'Transparent' : hex}
               />
             ))}
-          </div>
-
-          <div className="mb-3 rounded-lg border border-black/10 bg-neutral-50/50 p-2.5">
-            <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-neutral-400">
-              Color wheel
-            </p>
-            <div className="flex justify-center">
-              <SolidColorWheel
-                value={HEX6.test(customColor) ? customColor : '#ffffff'}
-                onChange={(hex) => applySolid(hex)}
-              />
-            </div>
           </div>
 
           <div className="flex items-center gap-2.5 rounded-lg border border-black/10 px-2.5 py-2">
@@ -567,13 +597,77 @@ export default function BackgroundPopover({
               onChange={(e) => {
                 const v = e.target.value
                 setCustomColor(v)
-                if (HEX6.test(v)) applySolid(v)
+                const hex = parseHexInput(v)
+                if (hex) applySolid(hex)
+              }}
+              onBlur={() => {
+                const hex = parseHexInput(customColor)
+                if (hex) {
+                  setCustomColor(hex)
+                  applySolid(hex)
+                  return
+                }
+                const fallback =
+                  value.type === 'solid' && typeof value.color === 'string'
+                    ? value.color
+                    : '#ffffff'
+                setCustomColor(fallback)
               }}
               className="min-w-0 flex-1 rounded-md border border-transparent bg-transparent px-1 py-0.5 font-mono text-[13px] font-medium text-neutral-800 outline-none transition focus:border-black/10"
               spellCheck={false}
+              autoComplete="off"
+              placeholder="#000000"
               aria-label="Hex color"
             />
           </div>
+
+          {showSolidPicker ? (
+            <div
+              className="fixed inset-0 z-[21000] flex items-center justify-center bg-black/30 p-4"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Color picker"
+              onMouseDown={(e) => {
+                if (e.target === e.currentTarget) setShowSolidPicker(false)
+              }}
+            >
+              <div
+                data-avnac-chrome
+                className="w-[min(420px,calc(100vw-2rem))] rounded-2xl border border-black/[0.08] bg-white p-3.5 shadow-2xl"
+              >
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <span className="text-[13px] font-semibold text-neutral-800">
+                    Color picker
+                  </span>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-2 rounded-md border border-black/10 bg-neutral-50 px-2 py-1 text-[11px] font-semibold text-neutral-700"
+                    onClick={() => setShowSolidPicker(false)}
+                  >
+                    Done
+                  </button>
+                </div>
+                <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-black/10 bg-white px-2 py-1">
+                  <span
+                    className="h-4 w-4 rounded-sm border border-black/15"
+                    style={{
+                      backgroundColor: HEX6.test(customColor)
+                        ? customColor
+                        : '#ffffff',
+                    }}
+                    aria-hidden
+                  />
+                  <span className="font-mono text-[11px] font-semibold text-neutral-700">
+                    {(HEX6.test(customColor) ? customColor : '#ffffff').toUpperCase()}
+                  </span>
+                </div>
+                <SolidColorRectPicker
+                  value={HEX6.test(customColor) ? customColor : '#ffffff'}
+                  onChange={(hex) => applySolid(hex)}
+                />
+              </div>
+            </div>
+          ) : null}
         </div>
       ) : (
         <div>

--- a/frontend/src/components/background-popover.tsx
+++ b/frontend/src/components/background-popover.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react'
 import EditorRangeSlider from './editor-range-slider'
 import { floatingToolbarPopoverClass } from './floating-toolbar-shell'
 
@@ -162,6 +169,223 @@ function clampAngle(n: number): number {
   return Math.min(360, Math.max(0, Math.round(n)))
 }
 
+type RgbColor = { r: number; g: number; b: number }
+type HsvColor = { h: number; s: number; v: number }
+
+const COLOR_WHEEL_SIZE = 168
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0
+  return Math.min(1, Math.max(0, n))
+}
+
+function clampByte(n: number): number {
+  return Math.min(255, Math.max(0, Math.round(n)))
+}
+
+function hexToRgb(hex: string): RgbColor | null {
+  if (!HEX6.test(hex)) return null
+  const s = hex.slice(1)
+  return {
+    r: parseInt(s.slice(0, 2), 16),
+    g: parseInt(s.slice(2, 4), 16),
+    b: parseInt(s.slice(4, 6), 16),
+  }
+}
+
+function rgbToHex(rgb: RgbColor): string {
+  const toHex = (n: number) => clampByte(n).toString(16).padStart(2, '0')
+  return `#${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`
+}
+
+function rgbToHsv(rgb: RgbColor): HsvColor {
+  const r = clamp01(rgb.r / 255)
+  const g = clamp01(rgb.g / 255)
+  const b = clamp01(rgb.b / 255)
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const d = max - min
+
+  let h = 0
+  if (d > 0) {
+    if (max === r) h = 60 * (((g - b) / d) % 6)
+    else if (max === g) h = 60 * ((b - r) / d + 2)
+    else h = 60 * ((r - g) / d + 4)
+  }
+
+  if (h < 0) h += 360
+  const s = max === 0 ? 0 : d / max
+  const v = max
+  return { h, s, v }
+}
+
+function hsvToRgb(hsv: HsvColor): RgbColor {
+  const h = ((hsv.h % 360) + 360) % 360
+  const s = clamp01(hsv.s)
+  const v = clamp01(hsv.v)
+  const c = v * s
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = v - c
+  let r1 = 0
+  let g1 = 0
+  let b1 = 0
+
+  if (h < 60) {
+    r1 = c
+    g1 = x
+  } else if (h < 120) {
+    r1 = x
+    g1 = c
+  } else if (h < 180) {
+    g1 = c
+    b1 = x
+  } else if (h < 240) {
+    g1 = x
+    b1 = c
+  } else if (h < 300) {
+    r1 = x
+    b1 = c
+  } else {
+    r1 = c
+    b1 = x
+  }
+
+  return {
+    r: clampByte((r1 + m) * 255),
+    g: clampByte((g1 + m) * 255),
+    b: clampByte((b1 + m) * 255),
+  }
+}
+
+function hexToHsv(hex: string): HsvColor | null {
+  const rgb = hexToRgb(hex)
+  if (!rgb) return null
+  return rgbToHsv(rgb)
+}
+
+function colorWheelMarker(hsv: HsvColor): { left: number; top: number } {
+  const radius = COLOR_WHEEL_SIZE / 2
+  const theta = (hsv.h * Math.PI) / 180
+  const dist = clamp01(hsv.s) * radius
+  return {
+    left: radius + Math.cos(theta) * dist,
+    top: radius + Math.sin(theta) * dist,
+  }
+}
+
+type SolidColorWheelProps = {
+  value: string
+  onChange: (hex: string) => void
+}
+
+function SolidColorWheel({ value, onChange }: SolidColorWheelProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const hsv = useMemo(() => hexToHsv(value) ?? { h: 0, s: 0, v: 1 }, [value])
+
+  const drawWheel = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const size = COLOR_WHEEL_SIZE
+    const radius = size / 2
+    canvas.width = size
+    canvas.height = size
+
+    const img = ctx.createImageData(size, size)
+    for (let y = 0; y < size; y += 1) {
+      for (let x = 0; x < size; x += 1) {
+        const dx = x - radius
+        const dy = y - radius
+        const dist = Math.hypot(dx, dy)
+        const idx = (y * size + x) * 4
+        if (dist > radius) {
+          img.data[idx + 3] = 0
+          continue
+        }
+        const h = ((Math.atan2(dy, dx) * 180) / Math.PI + 360) % 360
+        const s = dist / radius
+        const rgb = hsvToRgb({ h, s, v: 1 })
+        img.data[idx] = rgb.r
+        img.data[idx + 1] = rgb.g
+        img.data[idx + 2] = rgb.b
+        img.data[idx + 3] = 255
+      }
+    }
+    ctx.putImageData(img, 0, 0)
+  }, [])
+
+  useEffect(() => {
+    drawWheel()
+  }, [drawWheel])
+
+  const updateFromPointer = useCallback(
+    (clientX: number, clientY: number) => {
+      const canvas = canvasRef.current
+      if (!canvas) return
+      const rect = canvas.getBoundingClientRect()
+      const radius = COLOR_WHEEL_SIZE / 2
+      let dx = clientX - rect.left - radius
+      let dy = clientY - rect.top - radius
+      let dist = Math.hypot(dx, dy)
+      if (dist > radius) {
+        dx = (dx / dist) * radius
+        dy = (dy / dist) * radius
+        dist = radius
+      }
+      const h = ((Math.atan2(dy, dx) * 180) / Math.PI + 360) % 360
+      const s = clamp01(dist / radius)
+      onChange(rgbToHex(hsvToRgb({ h, s, v: 1 })))
+    },
+    [onChange],
+  )
+
+  const marker = colorWheelMarker(hsv)
+
+  return (
+    <div className="relative h-[168px] w-[168px]">
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full rounded-full border border-black/15 shadow-[inset_0_1px_8px_rgba(0,0,0,0.1)]"
+        onPointerDown={(e) => {
+          e.preventDefault()
+          e.currentTarget.setPointerCapture(e.pointerId)
+          setDragging(true)
+          updateFromPointer(e.clientX, e.clientY)
+        }}
+        onPointerMove={(e) => {
+          if (!dragging) return
+          updateFromPointer(e.clientX, e.clientY)
+        }}
+        onPointerUp={(e) => {
+          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.currentTarget.releasePointerCapture(e.pointerId)
+          }
+          setDragging(false)
+        }}
+        onPointerCancel={(e) => {
+          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.currentTarget.releasePointerCapture(e.pointerId)
+          }
+          setDragging(false)
+        }}
+        aria-label="Color wheel"
+      />
+      <span
+        className="pointer-events-none absolute z-[1] h-3.5 w-3.5 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.45)]"
+        style={{
+          left: marker.left,
+          top: marker.top,
+          transform: 'translate(-50%, -50%)',
+        }}
+        aria-hidden
+      />
+    </div>
+  )
+}
+
 export function bgValueToCss(v: BgValue): string {
   return v.type === 'solid' ? v.color : v.css
 }
@@ -299,6 +523,18 @@ export default function BackgroundPopover({
                 title={hex === 'transparent' ? 'Transparent' : hex}
               />
             ))}
+          </div>
+
+          <div className="mb-3 rounded-lg border border-black/10 bg-neutral-50/50 p-2.5">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-neutral-400">
+              Color wheel
+            </p>
+            <div className="flex justify-center">
+              <SolidColorWheel
+                value={HEX6.test(customColor) ? customColor : '#ffffff'}
+                onChange={(hex) => applySolid(hex)}
+              />
+            </div>
           </div>
 
           <div className="flex items-center gap-2.5 rounded-lg border border-black/10 px-2.5 py-2">

--- a/frontend/src/components/editor-export-menu.tsx
+++ b/frontend/src/components/editor-export-menu.tsx
@@ -14,12 +14,23 @@ export type ExportPngOptions = {
   crop?: PngExportCrop;
 };
 
+export type ExportJpegOptions = {
+  multiplier: number;
+  quality?: number;
+  crop?: PngExportCrop;
+};
+
+export type ExportRequest =
+  | ({ format: "png" } & ExportPngOptions)
+  | ({ format: "jpeg" } & ExportJpegOptions)
+  | { format: "svg" };
+
 const DEFAULT_EXPORT: ExportPngOptions = {
   multiplier: 1,
   transparent: false,
 };
 
-const PANEL_ESTIMATE_H = 220;
+const PANEL_ESTIMATE_H = 280;
 
 const exportTriggerClass = [
   "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/[0.08] px-4 text-sm font-medium sm:h-10 sm:px-5",
@@ -33,11 +44,12 @@ const exportTriggerClass = [
 
 type Props = {
   disabled?: boolean;
-  onExport: (opts: ExportPngOptions) => void;
+  onExport: (opts: ExportRequest) => void;
 };
 
 export default function EditorExportMenu({ disabled, onExport }: Props) {
   const [open, setOpen] = useState(false);
+  const [format, setFormat] = useState<"png" | "jpeg" | "svg">("png");
   const [opts, setOpts] = useState<ExportPngOptions>(DEFAULT_EXPORT);
   const posthog = usePostHog();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -63,6 +75,15 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
   }, [open]);
 
   const mult = Math.max(1, Math.min(3, Math.round(opts.multiplier)));
+  const isRaster = format !== "svg";
+  const showTransparentToggle = format === "png";
+  const formatBtn = (active: boolean) =>
+    [
+      "rounded-lg px-2.5 py-1.5 text-[12px] font-semibold transition-colors",
+      active
+        ? "bg-neutral-900 text-white shadow-sm"
+        : "text-neutral-600 hover:bg-black/[0.05] hover:text-neutral-800",
+    ].join(" ");
 
   return (
     <div ref={rootRef} className="relative shrink-0">
@@ -97,45 +118,108 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
           role="dialog"
           aria-label="Export"
         >
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <span className="text-[13px] font-medium text-neutral-800">
-              Export scale
-            </span>
-            <span className="text-[13px] tabular-nums text-neutral-600">
-              {mult}×
-            </span>
+          <div className="mb-4 flex items-center gap-1 rounded-lg bg-neutral-100 p-0.5">
+            <button
+              type="button"
+              className={formatBtn(format === "png")}
+              onClick={() => setFormat("png")}
+            >
+              PNG
+            </button>
+            <button
+              type="button"
+              className={formatBtn(format === "jpeg")}
+              onClick={() => setFormat("jpeg")}
+            >
+              JPEG
+            </button>
+            <button
+              type="button"
+              className={formatBtn(format === "svg")}
+              onClick={() => setFormat("svg")}
+            >
+              SVG
+            </button>
           </div>
-          <EditorRangeSlider
-            min={1}
-            max={3}
-            step={1}
-            value={mult}
-            onChange={(n) =>
-              setOpts((p) => ({ ...p, multiplier: Math.round(n) }))
-            }
-            aria-label="PNG export scale"
-            aria-valuemin={1}
-            aria-valuemax={3}
-            aria-valuenow={mult}
-            trackClassName="mb-4 w-full"
-          />
-          <label className="mb-4 flex cursor-pointer items-center gap-2.5 text-[13px] text-neutral-800">
-            <input
-              type="checkbox"
-              checked={opts.transparent}
-              onChange={(e) =>
-                setOpts((p) => ({ ...p, transparent: e.target.checked }))
-              }
-              className="size-4 shrink-0 rounded border border-black/20"
-              style={{ accentColor: "var(--accent)" }}
-            />
-            Transparent background
-          </label>
+          {isRaster ? (
+            <>
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <span className="text-[13px] font-medium text-neutral-800">
+                  Export scale
+                </span>
+                <span className="text-[13px] tabular-nums text-neutral-600">
+                  {mult}×
+                </span>
+              </div>
+              <EditorRangeSlider
+                min={1}
+                max={3}
+                step={1}
+                value={mult}
+                onChange={(n) =>
+                  setOpts((p) => ({ ...p, multiplier: Math.round(n) }))
+                }
+                aria-label={`${format.toUpperCase()} export scale`}
+                aria-valuemin={1}
+                aria-valuemax={3}
+                aria-valuenow={mult}
+                trackClassName="mb-4 w-full"
+              />
+              {showTransparentToggle ? (
+                <label className="mb-4 flex cursor-pointer items-center gap-2.5 text-[13px] text-neutral-800">
+                  <input
+                    type="checkbox"
+                    checked={opts.transparent}
+                    onChange={(e) =>
+                      setOpts((p) => ({ ...p, transparent: e.target.checked }))
+                    }
+                    className="size-4 shrink-0 rounded border border-black/20"
+                    style={{ accentColor: "var(--accent)" }}
+                  />
+                  Transparent background
+                </label>
+              ) : (
+                <p className="mb-4 text-[12px] text-neutral-600">
+                  JPEG exports flatten transparency to the canvas background.
+                </p>
+              )}
+            </>
+          ) : (
+            <p className="mb-4 text-[12px] text-neutral-600">
+              SVG preserves vectors and text when possible.
+            </p>
+          )}
           <button
             type="button"
             className="w-full rounded-lg bg-neutral-900 py-2.5 text-[13px] font-medium text-white transition-colors hover:bg-neutral-800"
             onClick={() => {
-              const finalOpts = { ...opts, multiplier: mult };
+              if (format === "svg") {
+                posthog.capture("svg_exported");
+                onExport({ format: "svg" });
+                setOpen(false);
+                return;
+              }
+
+              if (format === "jpeg") {
+                const finalOpts = {
+                  format: "jpeg" as const,
+                  multiplier: mult,
+                  quality: 0.92,
+                };
+                posthog.capture("jpeg_exported", {
+                  scale: finalOpts.multiplier,
+                  quality: finalOpts.quality,
+                });
+                onExport(finalOpts);
+                setOpen(false);
+                return;
+              }
+
+              const finalOpts = {
+                format: "png" as const,
+                ...opts,
+                multiplier: mult,
+              };
               posthog.capture("png_exported", {
                 scale: finalOpts.multiplier,
                 transparent: finalOpts.transparent,
@@ -144,7 +228,7 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
               setOpen(false);
             }}
           >
-            Download PNG
+            Download {format.toUpperCase()}
           </button>
         </div>
       ) : null}

--- a/frontend/src/components/editor-export-menu.tsx
+++ b/frontend/src/components/editor-export-menu.tsx
@@ -82,7 +82,7 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
       "rounded-lg px-2.5 py-1.5 text-[12px] font-semibold transition-colors",
       active
         ? "bg-neutral-900 text-white shadow-sm"
-        : "text-neutral-600 hover:bg-black/[0.05] hover:text-neutral-800",
+        : "bg-neutral-100 text-neutral-600 hover:bg-neutral-200 hover:text-neutral-800",
     ].join(" ");
 
   return (
@@ -118,7 +118,7 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
           role="dialog"
           aria-label="Export"
         >
-          <div className="mb-4 flex items-center gap-1 rounded-lg bg-neutral-100 p-0.5">
+          <div className="mb-4 flex items-center gap-1">
             <button
               type="button"
               className={formatBtn(format === "png")}

--- a/frontend/src/components/fabric-editor.tsx
+++ b/frontend/src/components/fabric-editor.tsx
@@ -143,6 +143,10 @@ import {
   loadExportSafeFabricImage,
   normalizeCanvasImagesForExport,
 } from '../lib/avnac-image-proxy'
+import {
+  downloadBlob,
+  safeAvnacFileBaseName,
+} from '../lib/avnac-files-export'
 import ShapeOptionsToolbar from './shape-options-toolbar'
 import TransparencyToolbarPopover from './transparency-toolbar-popover'
 import ShapesPopover, {
@@ -174,7 +178,11 @@ import ImageCropModal, {
   type ImageCropModalApplyPayload,
 } from './image-crop-modal'
 import { getAvnacLocked, setAvnacLocked } from '../lib/avnac-object-lock'
-import type { ExportPngOptions } from './editor-export-menu'
+import type {
+  ExportJpegOptions,
+  ExportPngOptions,
+  PngExportCrop,
+} from './editor-export-menu'
 import EditorFloatingSidebar, {
   type EditorSidebarPanelId,
 } from './editor-floating-sidebar'
@@ -341,6 +349,10 @@ function fabricObjectLabel(
 
 export type FabricEditorHandle = {
   exportPng: (opts?: ExportPngOptions) => void
+  exportJpeg: (opts?: ExportJpegOptions) => void
+  exportSvg: () => void
+  undo: () => void
+  redo: () => void
   saveDocument: () => void
   loadDocument: (file: File) => Promise<void>
 }
@@ -3171,103 +3183,190 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
     pasteFromClipboard,
   ])
 
+  const exportBaseName = useCallback(() => {
+    return safeAvnacFileBaseName(persistDisplayNameRef.current || 'Untitled')
+  }, [])
+
+  const resolveExportBounds = useCallback((crop: PngExportCrop = 'none') => {
+    const canvas = fabricCanvasRef.current
+    if (!canvas) {
+      return {
+        left: 0,
+        top: 0,
+        width: artboardWRef.current,
+        height: artboardHRef.current,
+      }
+    }
+
+    const aw = artboardWRef.current
+    const ah = artboardHRef.current
+    let left = 0
+    let top = 0
+    let width = aw
+    let height = ah
+
+    if (crop === 'selection') {
+      const active = canvas.getActiveObject()
+      if (active) {
+        const br = active.getBoundingRect()
+        left = br.left
+        top = br.top
+        width = Math.max(1, br.width)
+        height = Math.max(1, br.height)
+      }
+    } else if (crop === 'content') {
+      const objs = canvas.getObjects()
+      if (objs.length) {
+        let minX = Infinity
+        let minY = Infinity
+        let maxX = -Infinity
+        let maxY = -Infinity
+        for (const o of objs) {
+          const br = o.getBoundingRect()
+          minX = Math.min(minX, br.left)
+          minY = Math.min(minY, br.top)
+          maxX = Math.max(maxX, br.left + br.width)
+          maxY = Math.max(maxY, br.top + br.height)
+        }
+        const pad = 32
+        left = Math.max(0, minX - pad)
+        top = Math.max(0, minY - pad)
+        width = Math.max(1, Math.min(aw, maxX + pad) - left)
+        height = Math.max(1, Math.min(ah, maxY + pad) - top)
+      }
+    }
+
+    return { left, top, width, height }
+  }, [])
+
+  const exportRaster = useCallback(
+    (
+      format: 'png' | 'jpeg',
+      opts?: {
+        multiplier?: number
+        transparent?: boolean
+        crop?: PngExportCrop
+        quality?: number
+      },
+    ) => {
+      void (async () => {
+        const canvas = fabricCanvasRef.current
+        const mod = fabricModRef.current
+        if (!canvas || !mod) return
+        setExportError(null)
+
+        const mult = opts?.multiplier ?? 1
+        const transparent = opts?.transparent ?? false
+        const crop = opts?.crop ?? 'none'
+        const bounds = resolveExportBounds(crop)
+
+        try {
+          await normalizeCanvasImagesForExport(canvas, mod)
+          const prevBg = canvas.backgroundColor
+          let resetBg = false
+          try {
+            if (format === 'png' && transparent) {
+              canvas.backgroundColor = 'transparent'
+              resetBg = true
+              canvas.requestRenderAll()
+            }
+
+            if (format === 'jpeg') {
+              canvas.backgroundColor =
+                typeof prevBg === 'string' && prevBg !== 'transparent'
+                  ? prevBg
+                  : '#ffffff'
+              resetBg = true
+              canvas.requestRenderAll()
+            }
+
+            const data = canvas.toDataURL({
+              format,
+              quality: format === 'jpeg' ? (opts?.quality ?? 0.92) : undefined,
+              multiplier: mult,
+              left: bounds.left,
+              top: bounds.top,
+              width: bounds.width,
+              height: bounds.height,
+            })
+
+            const a = document.createElement('a')
+            a.href = data
+            const suffix = crop === 'none' ? '' : '-cropped'
+            a.download = `${exportBaseName()}${suffix}.${format === 'png' ? 'png' : 'jpg'}`
+            a.click()
+          } finally {
+            if (resetBg) {
+              canvas.backgroundColor = prevBg
+              canvas.requestRenderAll()
+            }
+          }
+        } catch (err) {
+          console.error(`FabricEditor: ${format.toUpperCase()} export failed`, err)
+          setExportError(
+            'Could not export this canvas. External images could not be prepared for download.',
+          )
+        }
+      })()
+    },
+    [exportBaseName, resolveExportBounds],
+  )
+
   const exportPng = useCallback((opts?: ExportPngOptions) => {
+    exportRaster('png', {
+      multiplier: opts?.multiplier,
+      transparent: opts?.transparent,
+      crop: opts?.crop,
+    })
+  }, [exportRaster])
+
+  const exportJpeg = useCallback((opts?: ExportJpegOptions) => {
+    exportRaster('jpeg', {
+      multiplier: opts?.multiplier,
+      quality: opts?.quality,
+      crop: opts?.crop,
+    })
+  }, [exportRaster])
+
+  const exportSvg = useCallback(() => {
     void (async () => {
       const canvas = fabricCanvasRef.current
       const mod = fabricModRef.current
       if (!canvas || !mod) return
       setExportError(null)
-      const mult = opts?.multiplier ?? 1
-      const transparent = opts?.transparent ?? false
-      const crop = opts?.crop ?? 'none'
-      const aw = artboardWRef.current
-      const ah = artboardHRef.current
-
-      let left = 0
-      let top = 0
-      let width = aw
-      let height = ah
-
-      if (crop === 'selection') {
-        const a = canvas.getActiveObject()
-        if (a) {
-          const br = a.getBoundingRect()
-          left = br.left
-          top = br.top
-          width = Math.max(1, br.width)
-          height = Math.max(1, br.height)
-        }
-      } else if (crop === 'content') {
-        const objs = canvas.getObjects()
-        if (objs.length) {
-          let minX = Infinity
-          let minY = Infinity
-          let maxX = -Infinity
-          let maxY = -Infinity
-          for (const o of objs) {
-            const br = o.getBoundingRect()
-            minX = Math.min(minX, br.left)
-            minY = Math.min(minY, br.top)
-            maxX = Math.max(maxX, br.left + br.width)
-            maxY = Math.max(maxY, br.top + br.height)
-          }
-          const pad = 32
-          left = Math.max(0, minX - pad)
-          top = Math.max(0, minY - pad)
-          width = Math.max(1, Math.min(aw, maxX + pad) - left)
-          height = Math.max(1, Math.min(ah, maxY + pad) - top)
-        }
-      }
-
       try {
         await normalizeCanvasImagesForExport(canvas, mod)
-        const prevBg = canvas.backgroundColor
-        try {
-          if (transparent) {
-            canvas.backgroundColor = 'transparent'
-            canvas.requestRenderAll()
-          }
-
-          const data = canvas.toDataURL({
-            format: 'png',
-            multiplier: mult,
-            left,
-            top,
+        const width = artboardWRef.current
+        const height = artboardHRef.current
+        const svg = canvas.toSVG({
+          width,
+          height,
+          viewBox: {
+            x: 0,
+            y: 0,
             width,
             height,
-          })
-
-          const a = document.createElement('a')
-          a.href = data
-          a.download =
-            crop === 'none' ? 'avnac-design.png' : 'avnac-design-cropped.png'
-          a.click()
-        } finally {
-          if (transparent) {
-            canvas.backgroundColor = prevBg
-            canvas.requestRenderAll()
-          }
-        }
+          },
+        })
+        const blob = new Blob([svg], {
+          type: 'image/svg+xml;charset=utf-8',
+        })
+        downloadBlob(blob, `${exportBaseName()}.svg`)
       } catch (err) {
-        console.error('FabricEditor: PNG export failed', err)
+        console.error('FabricEditor: SVG export failed', err)
         setExportError(
           'Could not export this canvas. External images could not be prepared for download.',
         )
       }
     })()
-  }, [])
+  }, [exportBaseName])
 
   const saveDocument = useCallback(() => {
     const doc = captureDoc()
     const blob = new Blob([JSON.stringify(doc, null, 2)], {
       type: 'application/json',
     })
-    const u = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = u
-    a.download = 'avnac-document.json'
-    a.click()
-    URL.revokeObjectURL(u)
+    downloadBlob(blob, 'avnac-document.json')
   }, [captureDoc])
 
   const loadDocument = useCallback(
@@ -3594,8 +3693,20 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
 
   useImperativeHandle(
     ref,
-    () => ({ exportPng, saveDocument, loadDocument }),
-    [exportPng, saveDocument, loadDocument],
+    () => ({
+      exportPng,
+      exportJpeg,
+      exportSvg,
+      undo: () => {
+        void undo()
+      },
+      redo: () => {
+        void redo()
+      },
+      saveDocument,
+      loadDocument,
+    }),
+    [exportPng, exportJpeg, exportSvg, undo, redo, saveDocument, loadDocument],
   )
 
   const onReadyChangeRef = useRef(onReadyChange)

--- a/frontend/src/components/fabric-editor.tsx
+++ b/frontend/src/components/fabric-editor.tsx
@@ -3272,12 +3272,17 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
             }
 
             if (format === 'jpeg') {
-              canvas.backgroundColor =
-                typeof prevBg === 'string' && prevBg !== 'transparent'
-                  ? prevBg
-                  : '#ffffff'
-              resetBg = true
-              canvas.requestRenderAll()
+              if (typeof prevBg === 'string') {
+                if (prevBg === 'transparent') {
+                  canvas.backgroundColor = '#ffffff'
+                  resetBg = true
+                  canvas.requestRenderAll()
+                }
+              } else if (prevBg == null) {
+                canvas.backgroundColor = '#ffffff'
+                resetBg = true
+                canvas.requestRenderAll()
+              }
             }
 
             const data = canvas.toDataURL({
@@ -3339,8 +3344,8 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
         const width = artboardWRef.current
         const height = artboardHRef.current
         const svg = canvas.toSVG({
-          width,
-          height,
+          width: String(width),
+          height: String(height),
           viewBox: {
             x: 0,
             y: 0,

--- a/frontend/src/lib/avnac-files-export.ts
+++ b/frontend/src/lib/avnac-files-export.ts
@@ -9,17 +9,21 @@ export function safeAvnacFileBaseName(name: string): string {
   return s || 'untitled'
 }
 
+export function downloadBlob(blob: Blob, fileName: string): void {
+  const u = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = u
+  a.download = fileName
+  a.click()
+  URL.revokeObjectURL(u)
+}
+
 export async function downloadAvnacJsonForId(id: string): Promise<boolean> {
   const record = await idbGetEditorRecord(id)
   if (!record) return false
   const blob = new Blob([JSON.stringify(record.document, null, 2)], {
     type: 'application/json',
   })
-  const u = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = u
-  a.download = `${safeAvnacFileBaseName(record.name ?? 'Untitled')}.avnac.json`
-  a.click()
-  URL.revokeObjectURL(u)
+  downloadBlob(blob, `${safeAvnacFileBaseName(record.name ?? 'Untitled')}.avnac.json`)
   return true
 }

--- a/frontend/src/lib/avnac-files-export.ts
+++ b/frontend/src/lib/avnac-files-export.ts
@@ -15,7 +15,8 @@ export function downloadBlob(blob: Blob, fileName: string): void {
   a.href = u
   a.download = fileName
   a.click()
-  URL.revokeObjectURL(u)
+  // Defer revocation so WebKit has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(u), 0)
 }
 
 export async function downloadAvnacJsonForId(id: string): Promise<boolean> {

--- a/frontend/src/routes/create.tsx
+++ b/frontend/src/routes/create.tsx
@@ -1,5 +1,9 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Home05Icon } from "@hugeicons/core-free-icons";
+import {
+  Home05Icon,
+  Redo02Icon,
+  Undo02Icon,
+} from "@hugeicons/core-free-icons";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
@@ -27,6 +31,9 @@ function parseSearchDimension(v: unknown): number | undefined {
   if (!Number.isFinite(n)) return undefined;
   return Math.min(16000, Math.max(100, Math.round(n)));
 }
+
+const headerActionClass =
+  "inline-flex size-9 shrink-0 items-center justify-center rounded-full border border-black/[0.1] bg-white/90 text-[var(--text)] outline-none transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-40 sm:size-10";
 
 export const Route = createFileRoute("/create")({
   validateSearch: (raw: Record<string, unknown>): CreateSearch => {
@@ -144,7 +151,7 @@ function CreatePage() {
 
   return (
     <div className="flex h-[100dvh] min-h-0 flex-col bg-[var(--surface-subtle)]">
-      <header className="flex flex-shrink-0 items-center gap-3 border-b border-[var(--line)] bg-[var(--surface)] px-4 py-3 sm:px-5 sm:py-3.5">
+      <header className="relative flex flex-shrink-0 items-center gap-3 border-b border-[var(--line)] bg-[var(--surface)] px-4 py-3 sm:px-5 sm:py-3.5">
         <Link
           to="/files"
           className="inline-flex size-10 shrink-0 items-center justify-center rounded-full text-[var(--text-muted)] no-underline transition-colors hover:bg-[var(--hover)] hover:text-[var(--text)]"
@@ -176,7 +183,51 @@ function CreatePage() {
             spellCheck={false}
           />
         </div>
+        <div className="pointer-events-none absolute inset-x-0 top-1/2 hidden -translate-y-1/2 justify-center sm:flex">
+          <div className="pointer-events-auto flex items-center gap-1.5">
+            <button
+              type="button"
+              className={headerActionClass}
+              disabled={!editorReady}
+              aria-label="Undo"
+              title="Undo (Cmd/Ctrl + Z)"
+              onClick={() => editorRef.current?.undo()}
+            >
+              <HugeiconsIcon icon={Undo02Icon} size={16} strokeWidth={1.9} />
+            </button>
+            <button
+              type="button"
+              className={headerActionClass}
+              disabled={!editorReady}
+              aria-label="Redo"
+              title="Redo (Cmd/Ctrl + Shift + Z)"
+              onClick={() => editorRef.current?.redo()}
+            >
+              <HugeiconsIcon icon={Redo02Icon} size={16} strokeWidth={1.9} />
+            </button>
+          </div>
+        </div>
         <div className="ml-auto flex shrink-0 items-center gap-1.5 sm:gap-2">
+          <button
+            type="button"
+            className={`${headerActionClass} sm:hidden`}
+            disabled={!editorReady}
+            aria-label="Undo"
+            title="Undo (Cmd/Ctrl + Z)"
+            onClick={() => editorRef.current?.undo()}
+          >
+            <HugeiconsIcon icon={Undo02Icon} size={16} strokeWidth={1.9} />
+          </button>
+          <button
+            type="button"
+            className={`${headerActionClass} sm:hidden`}
+            disabled={!editorReady}
+            aria-label="Redo"
+            title="Redo (Cmd/Ctrl + Shift + Z)"
+            onClick={() => editorRef.current?.redo()}
+          >
+            <HugeiconsIcon icon={Redo02Icon} size={16} strokeWidth={1.9} />
+          </button>
           <EditorExportMenu
             disabled={!editorReady}
             onExport={onExport}

--- a/frontend/src/routes/create.tsx
+++ b/frontend/src/routes/create.tsx
@@ -3,7 +3,9 @@ import { Home05Icon } from "@hugeicons/core-free-icons";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
-import EditorExportMenu from "../components/editor-export-menu";
+import EditorExportMenu, {
+  type ExportRequest,
+} from "../components/editor-export-menu";
 import FabricEditor, {
   type FabricEditorHandle,
 } from "../components/fabric-editor";
@@ -85,6 +87,20 @@ function CreatePage() {
     }
   };
 
+  const onExport = (req: ExportRequest) => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    if (req.format === "svg") {
+      editor.exportSvg();
+      return;
+    }
+    if (req.format === "jpeg") {
+      editor.exportJpeg(req);
+      return;
+    }
+    editor.exportPng(req);
+  };
+
   if (editorUnsupported) {
     return (
       <main className="hero-page relative flex min-h-[100dvh] flex-col overflow-hidden px-5 py-12 sm:px-8 sm:py-16">
@@ -163,7 +179,7 @@ function CreatePage() {
         <div className="ml-auto flex shrink-0 items-center gap-1.5 sm:gap-2">
           <EditorExportMenu
             disabled={!editorReady}
-            onExport={(opts) => editorRef.current?.exportPng(opts)}
+            onExport={onExport}
           />
         </div>
       </header>


### PR DESCRIPTION

[recording.webm](https://github.com/user-attachments/assets/3091fa7d-ca94-41ff-8c55-bfb13d6173d5)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SVG and JPEG export with a simple format toggle, undo/redo header buttons, and a modal color picker for solid backgrounds. Improves export options, filenames, and editing speed.

- New Features
  - Export menu supports PNG, JPEG, and SVG with a quick format switch; raster exports have scale; PNG can be transparent; JPEG flattens to the canvas background; SVG preserves vectors.
  - Cropped exports respect selection/content bounds; filenames derive from the document name.
  - Undo/Redo buttons added to the header (centered on desktop, in actions on mobile) with shortcut hints.
  - Solid color picker modal (SV rectangle + hue slider) opened via a color wheel; close with ESC, Done, or the backdrop; hex input is validated and normalized on blur.

- Refactors
  - `FabricEditor` exposes `exportJpeg`, `exportSvg`, `undo`, and `redo`; shared raster export path handles bounds, background rules, and image normalization; SVG uses a viewBox; filenames use a safe base name.
  - Introduced `downloadBlob`; used for SVG exports and document saves.
  - `EditorExportMenu` `onExport` now accepts an `ExportRequest`; the create route dispatches to the correct export method.

<sup>Written for commit 79d2abda50fdeb16bd269d868f6be0e7b77f22ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



