### PR TITLE
fix(frontend): prevent mobile scroll jitter on landing page

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -314,7 +314,7 @@ function Landing() {
 
   return (
     <main className="landing-page">
-      <section className="hero-page relative flex min-h-[100dvh] flex-col justify-center overflow-hidden px-5 py-16 sm:px-10 sm:py-20 lg:px-16 lg:py-24">
+      <section className="hero-page relative flex min-h-[100svh] flex-col justify-center overflow-hidden px-5 py-16 sm:px-10 sm:py-20 lg:px-16 lg:py-24">
         <div className="hero-bg-orb hero-bg-orb-a" aria-hidden="true" />
         <div className="hero-bg-orb hero-bg-orb-b" aria-hidden="true" />
         <div className="hero-grid" aria-hidden="true" />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -56,6 +56,7 @@
     font-family: var(--font-sans);
     background-color: var(--surface-subtle);
     overflow-x: hidden;
+    overscroll-behavior-y: none;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }


### PR DESCRIPTION


https://github.com/user-attachments/assets/bece51bb-2b58-49de-b856-ef9417ec0e85

## Summary
- The landing hero used `min-h-[100dvh]`. On mobile, `dvh` recalculates as the URL bar shows/hides, so reaching the page bottom triggered a viewport resize that reflowed the hero and pushed jitter up the rest of the page.
- Switched the hero to `min-h-[100svh]` so its height is locked to the small viewport and never changes mid-scroll.
- Added `overscroll-behavior-y: none` to `body` so rubber-band scrolling at the page edges no longer re-toggles the URL bar (which was the trigger for the resize loop).

## Test plan
- [x] Run frontend locally and load on a physical phone over LAN
- [x] Scroll to the bottom of the landing page on mobile and confirm the jitter is gone
- [x] Confirm the hero still fills the viewport on initial load
- [x] Spot-check desktop landing layout is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile scroll jitter on the landing page by switching the hero from 100dvh to 100svh and disabling vertical overscroll on the body to stop URL bar toggling. This stabilizes the hero height and prevents mid-scroll reflows on mobile.

<sup>Written for commit d5aee0536586aeede8543e6c3e0c051e604b88cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

