### PR TITLE
feat(editor): add SVG export

### DIFF
--- a/frontend/src/components/editor-export-menu.tsx
+++ b/frontend/src/components/editor-export-menu.tsx
@@ -14,12 +14,22 @@ export type ExportPngOptions = {
   crop?: PngExportCrop;
 };
 
-const DEFAULT_EXPORT: ExportPngOptions = {
+export type ExportSvgOptions = {
+  transparent: boolean;
+};
+
+export type ExportFormat = "png" | "svg";
+
+const DEFAULT_PNG: ExportPngOptions = {
   multiplier: 1,
   transparent: false,
 };
 
-const PANEL_ESTIMATE_H = 220;
+const DEFAULT_SVG: ExportSvgOptions = {
+  transparent: false,
+};
+
+const PANEL_ESTIMATE_H = 260;
 
 const exportTriggerClass = [
   "inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-full border border-black/[0.08] px-4 text-sm font-medium sm:h-10 sm:px-5",
@@ -31,14 +41,29 @@ const exportTriggerClass = [
   "disabled:pointer-events-none disabled:opacity-40",
 ].join(" ");
 
+const formatTabClass = (active: boolean) =>
+  [
+    "flex-1 rounded-md py-1.5 text-[12px] font-medium transition-colors",
+    active
+      ? "bg-white text-neutral-900 shadow-[0_1px_2px_rgba(0,0,0,0.06)]"
+      : "text-neutral-600 hover:text-neutral-900",
+  ].join(" ");
+
 type Props = {
   disabled?: boolean;
   onExport: (opts: ExportPngOptions) => void;
+  onExportSvg?: (opts: ExportSvgOptions) => void;
 };
 
-export default function EditorExportMenu({ disabled, onExport }: Props) {
+export default function EditorExportMenu({
+  disabled,
+  onExport,
+  onExportSvg,
+}: Props) {
   const [open, setOpen] = useState(false);
-  const [opts, setOpts] = useState<ExportPngOptions>(DEFAULT_EXPORT);
+  const [format, setFormat] = useState<ExportFormat>("png");
+  const [pngOpts, setPngOpts] = useState<ExportPngOptions>(DEFAULT_PNG);
+  const [svgOpts, setSvgOpts] = useState<ExportSvgOptions>(DEFAULT_SVG);
   const posthog = usePostHog();
   const rootRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -62,7 +87,7 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
     return () => document.removeEventListener("mousedown", onDown);
   }, [open]);
 
-  const mult = Math.max(1, Math.min(3, Math.round(opts.multiplier)));
+  const mult = Math.max(1, Math.min(3, Math.round(pngOpts.multiplier)));
 
   return (
     <div ref={rootRef} className="relative shrink-0">
@@ -97,55 +122,117 @@ export default function EditorExportMenu({ disabled, onExport }: Props) {
           role="dialog"
           aria-label="Export"
         >
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <span className="text-[13px] font-medium text-neutral-800">
-              Export scale
-            </span>
-            <span className="text-[13px] tabular-nums text-neutral-600">
-              {mult}×
-            </span>
-          </div>
-          <EditorRangeSlider
-            min={1}
-            max={3}
-            step={1}
-            value={mult}
-            onChange={(n) =>
-              setOpts((p) => ({ ...p, multiplier: Math.round(n) }))
-            }
-            aria-label="PNG export scale"
-            aria-valuemin={1}
-            aria-valuemax={3}
-            aria-valuenow={mult}
-            trackClassName="mb-4 w-full"
-          />
-          <label className="mb-4 flex cursor-pointer items-center gap-2.5 text-[13px] text-neutral-800">
-            <input
-              type="checkbox"
-              checked={opts.transparent}
-              onChange={(e) =>
-                setOpts((p) => ({ ...p, transparent: e.target.checked }))
-              }
-              className="size-4 shrink-0 rounded border border-black/20"
-              style={{ accentColor: "var(--accent)" }}
-            />
-            Transparent background
-          </label>
-          <button
-            type="button"
-            className="w-full rounded-lg bg-neutral-900 py-2.5 text-[13px] font-medium text-white transition-colors hover:bg-neutral-800"
-            onClick={() => {
-              const finalOpts = { ...opts, multiplier: mult };
-              posthog.capture("png_exported", {
-                scale: finalOpts.multiplier,
-                transparent: finalOpts.transparent,
-              });
-              onExport(finalOpts);
-              setOpen(false);
-            }}
+          <div
+            className="mb-3 flex gap-1 rounded-lg bg-black/[0.04] p-1"
+            role="tablist"
+            aria-label="Export format"
           >
-            Download PNG
-          </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={format === "png"}
+              className={formatTabClass(format === "png")}
+              onClick={() => setFormat("png")}
+            >
+              PNG
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={format === "svg"}
+              className={formatTabClass(format === "svg")}
+              onClick={() => setFormat("svg")}
+            >
+              SVG
+            </button>
+          </div>
+
+          {format === "png" ? (
+            <>
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <span className="text-[13px] font-medium text-neutral-800">
+                  Export scale
+                </span>
+                <span className="text-[13px] tabular-nums text-neutral-600">
+                  {mult}×
+                </span>
+              </div>
+              <EditorRangeSlider
+                min={1}
+                max={3}
+                step={1}
+                value={mult}
+                onChange={(n) =>
+                  setPngOpts((p) => ({ ...p, multiplier: Math.round(n) }))
+                }
+                aria-label="PNG export scale"
+                aria-valuemin={1}
+                aria-valuemax={3}
+                aria-valuenow={mult}
+                trackClassName="mb-4 w-full"
+              />
+              <label className="mb-4 flex cursor-pointer items-center gap-2.5 text-[13px] text-neutral-800">
+                <input
+                  type="checkbox"
+                  checked={pngOpts.transparent}
+                  onChange={(e) =>
+                    setPngOpts((p) => ({ ...p, transparent: e.target.checked }))
+                  }
+                  className="size-4 shrink-0 rounded border border-black/20"
+                  style={{ accentColor: "var(--accent)" }}
+                />
+                Transparent background
+              </label>
+              <button
+                type="button"
+                className="w-full rounded-lg bg-neutral-900 py-2.5 text-[13px] font-medium text-white transition-colors hover:bg-neutral-800"
+                onClick={() => {
+                  const finalOpts = { ...pngOpts, multiplier: mult };
+                  posthog.capture("png_exported", {
+                    scale: finalOpts.multiplier,
+                    transparent: finalOpts.transparent,
+                  });
+                  onExport(finalOpts);
+                  setOpen(false);
+                }}
+              >
+                Download PNG
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="mb-3 text-[12px] leading-snug text-neutral-600">
+                Vector export. Scales infinitely without quality loss.
+              </p>
+              <label className="mb-4 flex cursor-pointer items-center gap-2.5 text-[13px] text-neutral-800">
+                <input
+                  type="checkbox"
+                  checked={svgOpts.transparent}
+                  onChange={(e) =>
+                    setSvgOpts((p) => ({ ...p, transparent: e.target.checked }))
+                  }
+                  className="size-4 shrink-0 rounded border border-black/20"
+                  style={{ accentColor: "var(--accent)" }}
+                />
+                Transparent background
+              </label>
+              <button
+                type="button"
+                disabled={!onExportSvg}
+                className="w-full rounded-lg bg-neutral-900 py-2.5 text-[13px] font-medium text-white transition-colors hover:bg-neutral-800 disabled:opacity-40"
+                onClick={() => {
+                  if (!onExportSvg) return;
+                  posthog.capture("svg_exported", {
+                    transparent: svgOpts.transparent,
+                  });
+                  onExportSvg(svgOpts);
+                  setOpen(false);
+                }}
+              >
+                Download SVG
+              </button>
+            </>
+          )}
         </div>
       ) : null}
     </div>

--- a/frontend/src/components/fabric-editor.tsx
+++ b/frontend/src/components/fabric-editor.tsx
@@ -174,7 +174,7 @@ import ImageCropModal, {
   type ImageCropModalApplyPayload,
 } from './image-crop-modal'
 import { getAvnacLocked, setAvnacLocked } from '../lib/avnac-object-lock'
-import type { ExportPngOptions } from './editor-export-menu'
+import type { ExportPngOptions, ExportSvgOptions } from './editor-export-menu'
 import EditorFloatingSidebar, {
   type EditorSidebarPanelId,
 } from './editor-floating-sidebar'
@@ -341,6 +341,7 @@ function fabricObjectLabel(
 
 export type FabricEditorHandle = {
   exportPng: (opts?: ExportPngOptions) => void
+  exportSvg: (opts?: ExportSvgOptions) => void
   saveDocument: () => void
   loadDocument: (file: File) => Promise<void>
 }
@@ -3257,6 +3258,53 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
     })()
   }, [])
 
+  const exportSvg = useCallback((opts?: ExportSvgOptions) => {
+    void (async () => {
+      const canvas = fabricCanvasRef.current
+      const mod = fabricModRef.current
+      if (!canvas || !mod) return
+      setExportError(null)
+      const transparent = opts?.transparent ?? false
+      const aw = artboardWRef.current
+      const ah = artboardHRef.current
+
+      try {
+        await normalizeCanvasImagesForExport(canvas, mod)
+        const prevBg = canvas.backgroundColor
+        try {
+          if (transparent) {
+            canvas.backgroundColor = 'transparent'
+            canvas.requestRenderAll()
+          }
+
+          const svg = canvas.toSVG({
+            width: `${aw}`,
+            height: `${ah}`,
+            viewBox: { x: 0, y: 0, width: aw, height: ah },
+          })
+
+          const blob = new Blob([svg], { type: 'image/svg+xml' })
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = 'avnac-design.svg'
+          a.click()
+          URL.revokeObjectURL(url)
+        } finally {
+          if (transparent) {
+            canvas.backgroundColor = prevBg
+            canvas.requestRenderAll()
+          }
+        }
+      } catch (err) {
+        console.error('FabricEditor: SVG export failed', err)
+        setExportError(
+          'Could not export this canvas. External images could not be prepared for download.',
+        )
+      }
+    })()
+  }, [])
+
   const saveDocument = useCallback(() => {
     const doc = captureDoc()
     const blob = new Blob([JSON.stringify(doc, null, 2)], {
@@ -3594,8 +3642,8 @@ const FabricEditor = forwardRef<FabricEditorHandle, FabricEditorProps>(
 
   useImperativeHandle(
     ref,
-    () => ({ exportPng, saveDocument, loadDocument }),
-    [exportPng, saveDocument, loadDocument],
+    () => ({ exportPng, exportSvg, saveDocument, loadDocument }),
+    [exportPng, exportSvg, saveDocument, loadDocument],
   )
 
   const onReadyChangeRef = useRef(onReadyChange)

--- a/frontend/src/routes/create.tsx
+++ b/frontend/src/routes/create.tsx
@@ -164,6 +164,7 @@ function CreatePage() {
           <EditorExportMenu
             disabled={!editorReady}
             onExport={(opts) => editorRef.current?.exportPng(opts)}
+            onExportSvg={(opts) => editorRef.current?.exportSvg(opts)}
           />
         </div>
       </header>


### PR DESCRIPTION
## Summary
- Adds SVG as a second download format in the export menu, alongside PNG.
- The menu now has a PNG / SVG segmented control. PNG keeps its existing scale slider + transparency toggle. SVG offers a transparency toggle.
- Output uses Fabric's built-in `canvas.toSVG()` with a viewBox sized to the artboard, so the file matches the design dimensions exactly. The same `normalizeCanvasImagesForExport` step the PNG path uses runs first, so external/Unsplash images embed cleanly instead of breaking on CORS.

## Why
PNG-only export is limiting for anyone taking work into print, web SVGs, or other vector tools. `canvas.toSVG()` is already in Fabric, so this is an additive feature with no new dependencies.

## Test plan
- [x] PNG export still works (scale 1-3x, transparent toggle)
- [x] SVG download produces a valid file with the artboard's viewBox/dimensions
- [x] Transparent toggle on SVG strips the background fill
- [x] Type check passes (no new errors introduced)
- [ ] Verify SVG renders correctly in another viewer (browser, Illustrator, Figma) for a canvas containing text + shapes + an image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SVG export alongside PNG with a simple format toggle. SVG files match the artboard size, support transparent backgrounds, and embed external images reliably; PNG behavior is unchanged.

<sup>Written for commit 2bc1e6eb2a2e976797fd54e25367919dc9b1dda8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

