### PR TITLE
fix: add shape positioning to avoid overlapping shapes

### DIFF
--- a/frontend/src/components/scene-editor.tsx
+++ b/frontend/src/components/scene-editor.tsx
@@ -618,73 +618,94 @@ const SceneEditor = forwardRef<SceneEditorHandle, SceneEditorProps>(
           blurPct: 0,
           shadow: null,
         }
+
+        // Center the object, then step it diagonally like duplicate/paste when occupied.
+        let positioned = createCenteredObject(common)
+        const maxX = Math.max(0, artboardW - positioned.width)
+        const maxY = Math.max(0, artboardH - positioned.height)
+        const centerOccupied = () => {
+          const centerX = positioned.x + positioned.width / 2
+          const centerY = positioned.y + positioned.height / 2
+          return doc.objects.some((obj) => {
+            const center = getObjectCenter(obj)
+            return Math.abs(center.x - centerX) < 2 && Math.abs(center.y - centerY) < 2
+          })
+        }
+        while (centerOccupied() && (positioned.x < maxX || positioned.y < maxY)) {
+          positioned = {
+            ...positioned,
+            x: Math.min(maxX, positioned.x + CLIPBOARD_PASTE_OFFSET),
+            y: Math.min(maxY, positioned.y + CLIPBOARD_PASTE_OFFSET),
+          }
+        }
+
         if (kind === 'rect') {
           addObjects([
-            createCenteredObject({
-              ...common,
+            {
+              ...positioned,
               type: 'rect',
               fill: DEFAULT_FILL,
               stroke: DEFAULT_STROKE,
               strokeWidth: 0,
               cornerRadius: Math.round(perfectSize * 0.06),
-            }),
+            },
           ])
           return
         }
         if (kind === 'ellipse') {
           addObjects([
-            createCenteredObject({
-              ...common,
+            {
+              ...positioned,
               type: 'ellipse',
               fill: DEFAULT_FILL,
               stroke: DEFAULT_STROKE,
               strokeWidth: 0,
-            }),
+            },
           ])
           return
         }
         if (kind === 'polygon') {
           addObjects([
-            createCenteredObject({
-              ...common,
+            {
+              ...positioned,
               type: 'polygon',
               fill: DEFAULT_FILL,
               stroke: DEFAULT_STROKE,
               strokeWidth: 0,
               sides: 6,
-            }),
+            },
           ])
           return
         }
         if (kind === 'star') {
           addObjects([
-            createCenteredObject({
-              ...common,
+            {
+              ...positioned,
               type: 'star',
               fill: DEFAULT_FILL,
               stroke: DEFAULT_STROKE,
               strokeWidth: 0,
               points: 5,
-            }),
+            },
           ])
           return
         }
         if (kind === 'line') {
           addObjects([
-            createCenteredObject({
-              ...common,
+            {
+              ...positioned,
               type: 'line',
               stroke: DEFAULT_LINE_STROKE,
               strokeWidth: 6,
               lineStyle: 'solid',
               roundedEnds: true,
-            }),
+            },
           ])
           return
         }
         addObjects([
-          createCenteredObject({
-            ...common,
+          {
+            ...positioned,
             type: 'arrow',
             stroke: DEFAULT_LINE_STROKE,
             strokeWidth: 6,
@@ -692,12 +713,12 @@ const SceneEditor = forwardRef<SceneEditorHandle, SceneEditorProps>(
             roundedEnds: true,
             pathType: 'straight',
             headSize: 1,
-            curveBulge: Math.round(common.height * 0.4),
+            curveBulge: Math.round(positioned.height * 0.4),
             curveT: 0.5,
-          }),
+          },
         ])
       },
-      [addObjects, createCenteredObject, defaultShapeBox],
+      [addObjects, artboardH, artboardW, createCenteredObject, defaultShapeBox, doc.objects],
     )
 
     const addText = useCallback(() => {


### PR DESCRIPTION
Summary: 

Add positional offset when you inserting shapes on the same coordinates just like on `duplicate`.

Previous behaviour:


https://github.com/user-attachments/assets/0d244725-9c7a-4209-be1b-6957d6901c23

Current behaviour:


https://github.com/user-attachments/assets/f518fe81-ee1e-4f2a-a0b3-adf0b86e7113



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid overlapping shapes when inserting at the same coordinates by offsetting new shapes diagonally, matching the duplicate/paste behavior. Shapes now auto-position within artboard bounds for a smoother creation flow.

- **Bug Fixes**
  - Center new shapes, then step diagonally by `CLIPBOARD_PASTE_OFFSET` until the center is free or bounds are reached.
  - Check center collisions with a 2px tolerance against existing objects.
  - Constrain offsets to `artboardW`/`artboardH`.
  - Apply to rect, ellipse, polygon, star, line, and arrow; set arrow `curveBulge` from the positioned height.
  - Updated callback dependencies to include `artboardH`, `artboardW`, and `doc.objects`.

<sup>Written for commit f26d4dc50be7b021297eaf48fc80eb634a65b202. Summary will update on new commits. <a href="https://cubic.dev/pr/akinloluwami/avnac/pull/16?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

