### PR TITLE
feat: move shapes on arrow keys press

### DIFF
--- a/frontend/src/components/scene-editor.tsx
+++ b/frontend/src/components/scene-editor.tsx
@@ -243,6 +243,7 @@ const SceneEditor = forwardRef<SceneEditorHandle, SceneEditorProps>(
     const editorStore = editorStoreRef.current
     const doc = useStore(editorStore, (state) => state.doc)
     const setDoc = useStore(editorStore, (state) => state.setDoc)
+    const hoveredId = useStore(editorStore, (state) => state.hoveredId)
     const selectedIds = useStore(editorStore, (state) => state.selectedIds)
     const setSelectedIds = useStore(editorStore, (state) => state.setSelectedIds)
     const setHoveredId = useStore(editorStore, (state) => state.setHoveredId)
@@ -508,17 +509,29 @@ const SceneEditor = forwardRef<SceneEditorHandle, SceneEditorProps>(
       selectedSingle?.type === 'group' && !selectedSingle.locked
 
     const nudgeSelection = useCallback((dx: number, dy: number) => {
-      if (selectedIds.length === 0) return
+      const targetIds =
+        selectedIds.length > 0
+          ? selectedIds
+          : hoveredId
+            ? [hoveredId]
+            : []
+      if (targetIds.length === 0) return
+
+      let movedAny = false
       setDoc((prev) => ({
         ...prev,
-        objects: prev.objects.map((obj) =>
-          selectedIds.includes(obj.id)
-            ? { ...obj, x: obj.x + dx, y: obj.y + dy }
-            : obj,
-        ),
+        objects: prev.objects.map((obj) => {
+          if (!targetIds.includes(obj.id) || obj.locked) return obj
+          movedAny = true
+          return { ...obj, x: obj.x + dx, y: obj.y + dy }
+        }),
       }))
+      if (!movedAny) return
+      if (selectedIds.length === 0 && hoveredId) {
+        setSelectedIds([hoveredId])
+      }
       setSelectionRev((n) => n + 1)
-    }, [selectedIds])
+    }, [hoveredId, selectedIds, setDoc, setSelectedIds])
 
     const pushSelectionToTop = useCallback((ids: string[]) => {
       setSelectedIds(ids)

--- a/frontend/src/components/scene-editor/use-editor-keyboard-shortcuts.ts
+++ b/frontend/src/components/scene-editor/use-editor-keyboard-shortcuts.ts
@@ -3,33 +3,33 @@ import {
   type Dispatch,
   type MutableRefObject,
   type SetStateAction,
-} from 'react'
+} from "react";
 
-import {
-  cloneAvnacDocument,
-  type AvnacDocument,
-} from '../../lib/avnac-scene'
-import type { LayerReorderKind } from '../../scene-engine/primitives'
+import { cloneAvnacDocument, type AvnacDocument } from "../../lib/avnac-scene";
+import type { LayerReorderKind } from "../../scene-engine/primitives";
 
-type AsyncCommand = () => void | Promise<void>
+type AsyncCommand = () => void | Promise<void>;
+
+const SELECTION_NUDGE_STEP_PX = 12;
+const SELECTION_NUDGE_LARGE_STEP_PX = 24;
 
 type UseEditorKeyboardShortcutsArgs = {
-  applyingHistoryRef: MutableRefObject<boolean>
-  commitTextDraft: () => void
-  copyElementToClipboard: AsyncCommand
-  deleteSelection: () => void
-  duplicateElement: AsyncCommand
-  groupSelection: () => void
-  historyIndexRef: MutableRefObject<number>
-  historyRef: MutableRefObject<AvnacDocument[]>
-  nudgeSelection: (dx: number, dy: number) => void
-  onZoomFitRequest: () => void
-  pasteFromClipboard: AsyncCommand
-  reorderSelectionLayers: (kind: LayerReorderKind) => void
-  setDoc: Dispatch<SetStateAction<AvnacDocument>>
-  setShortcutsOpen: (open: boolean) => void
-  ungroupSelection: () => void
-}
+  applyingHistoryRef: MutableRefObject<boolean>;
+  commitTextDraft: () => void;
+  copyElementToClipboard: AsyncCommand;
+  deleteSelection: () => void;
+  duplicateElement: AsyncCommand;
+  groupSelection: () => void;
+  historyIndexRef: MutableRefObject<number>;
+  historyRef: MutableRefObject<AvnacDocument[]>;
+  nudgeSelection: (dx: number, dy: number) => void;
+  onZoomFitRequest: () => void;
+  pasteFromClipboard: AsyncCommand;
+  reorderSelectionLayers: (kind: LayerReorderKind) => void;
+  setDoc: Dispatch<SetStateAction<AvnacDocument>>;
+  setShortcutsOpen: (open: boolean) => void;
+  ungroupSelection: () => void;
+};
 
 export function useEditorKeyboardShortcuts({
   applyingHistoryRef,
@@ -50,107 +50,123 @@ export function useEditorKeyboardShortcuts({
 }: UseEditorKeyboardShortcutsArgs) {
   useEffect(() => {
     const restoreHistorySnapshot = (nextIndex: number) => {
-      const snap = historyRef.current[nextIndex]
-      if (!snap) return
-      applyingHistoryRef.current = true
-      historyIndexRef.current = nextIndex
-      setDoc(cloneAvnacDocument(snap))
+      const snap = historyRef.current[nextIndex];
+      if (!snap) return;
+      applyingHistoryRef.current = true;
+      historyIndexRef.current = nextIndex;
+      setDoc(cloneAvnacDocument(snap));
       window.setTimeout(() => {
-        applyingHistoryRef.current = false
-      }, 0)
-    }
+        applyingHistoryRef.current = false;
+      }, 0);
+    };
 
     const onKey = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null
+      const target = e.target as HTMLElement | null;
       const editingTextInput =
         target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.isContentEditable)
-      if (e.key === '?' && !editingTextInput) {
-        e.preventDefault()
-        setShortcutsOpen(true)
-        return
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable);
+      if (e.key === "?" && !editingTextInput) {
+        e.preventDefault();
+        setShortcutsOpen(true);
+        return;
       }
       if (editingTextInput) {
-        if (e.key === 'Escape') {
-          e.preventDefault()
-          commitTextDraft()
+        if (e.key === "Escape") {
+          e.preventDefault();
+          commitTextDraft();
         }
-        return
+        return;
       }
-      const mod = e.metaKey || e.ctrlKey
-      if (mod && e.key.toLowerCase() === 'z') {
-        e.preventDefault()
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "z") {
+        e.preventDefault();
         const nextIndex = e.shiftKey
           ? Math.min(historyRef.current.length - 1, historyIndexRef.current + 1)
-          : Math.max(0, historyIndexRef.current - 1)
-        restoreHistorySnapshot(nextIndex)
-        return
+          : Math.max(0, historyIndexRef.current - 1);
+        restoreHistorySnapshot(nextIndex);
+        return;
       }
-      if (mod && e.key.toLowerCase() === 'g') {
-        e.preventDefault()
-        if (e.shiftKey) ungroupSelection()
-        else groupSelection()
-        return
+      if (mod && e.key.toLowerCase() === "g") {
+        e.preventDefault();
+        if (e.shiftKey) ungroupSelection();
+        else groupSelection();
+        return;
       }
-      if (mod && e.key.toLowerCase() === 'd') {
-        e.preventDefault()
-        void duplicateElement()
-        return
+      if (mod && e.key.toLowerCase() === "d") {
+        e.preventDefault();
+        void duplicateElement();
+        return;
       }
-      if (mod && e.key.toLowerCase() === 'c') {
-        e.preventDefault()
-        void copyElementToClipboard()
-        return
+      if (mod && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        void copyElementToClipboard();
+        return;
       }
-      if (mod && e.key.toLowerCase() === 'v') {
-        e.preventDefault()
-        void pasteFromClipboard()
-        return
+      if (mod && e.key.toLowerCase() === "v") {
+        e.preventDefault();
+        void pasteFromClipboard();
+        return;
       }
-      if (mod && e.code === 'BracketRight') {
-        e.preventDefault()
-        reorderSelectionLayers(e.shiftKey ? 'front' : 'forward')
-        return
+      if (mod && e.code === "BracketRight") {
+        e.preventDefault();
+        reorderSelectionLayers(e.shiftKey ? "front" : "forward");
+        return;
       }
-      if (mod && e.code === 'BracketLeft') {
-        e.preventDefault()
-        reorderSelectionLayers(e.shiftKey ? 'back' : 'backward')
-        return
+      if (mod && e.code === "BracketLeft") {
+        e.preventDefault();
+        reorderSelectionLayers(e.shiftKey ? "back" : "backward");
+        return;
       }
-      if (e.key === 'Delete' || e.key === 'Backspace') {
-        e.preventDefault()
-        deleteSelection()
-        return
+      if (e.key === "Delete" || e.key === "Backspace") {
+        e.preventDefault();
+        deleteSelection();
+        return;
       }
-      if (e.key === 'ArrowLeft') {
-        e.preventDefault()
-        nudgeSelection(e.shiftKey ? -10 : -1, 0)
-        return
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        nudgeSelection(
+          e.shiftKey
+            ? -SELECTION_NUDGE_LARGE_STEP_PX
+            : -SELECTION_NUDGE_STEP_PX,
+          0,
+        );
+        return;
       }
-      if (e.key === 'ArrowRight') {
-        e.preventDefault()
-        nudgeSelection(e.shiftKey ? 10 : 1, 0)
-        return
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        nudgeSelection(
+          e.shiftKey ? SELECTION_NUDGE_LARGE_STEP_PX : SELECTION_NUDGE_STEP_PX,
+          0,
+        );
+        return;
       }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        nudgeSelection(0, e.shiftKey ? -10 : -1)
-        return
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        nudgeSelection(
+          0,
+          e.shiftKey
+            ? -SELECTION_NUDGE_LARGE_STEP_PX
+            : -SELECTION_NUDGE_STEP_PX,
+        );
+        return;
       }
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
-        nudgeSelection(0, e.shiftKey ? 10 : 1)
-        return
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        nudgeSelection(
+          0,
+          e.shiftKey ? SELECTION_NUDGE_LARGE_STEP_PX : SELECTION_NUDGE_STEP_PX,
+        );
+        return;
       }
-      if (mod && e.key === '1') {
-        e.preventDefault()
-        onZoomFitRequest()
+      if (mod && e.key === "1") {
+        e.preventDefault();
+        onZoomFitRequest();
       }
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, [
     applyingHistoryRef,
     commitTextDraft,
@@ -167,5 +183,5 @@ export function useEditorKeyboardShortcuts({
     setDoc,
     setShortcutsOpen,
     ungroupSelection,
-  ])
+  ]);
 }


### PR DESCRIPTION
Added the ability to move shapes using the arrow keys(up,down,right,left)
Plus the ability to accelerate movement using key shift + `arrow-key` combination

A short demo:


https://github.com/user-attachments/assets/de588c1c-d463-4a25-b597-708658bdb3fa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akinloluwami/codesmith/avnac/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add arrow key nudging to move shapes in the editor. Shift+Arrow moves faster and respects locked items.

- **New Features**
  - Arrow keys nudge by 12px; Shift+Arrow by 24px.
  - If nothing is selected, nudging moves the hovered shape and selects it.
  - Locked shapes are skipped during nudging.

<sup>Written for commit 125dcee783ad4497a0b6f3c32d5570dd6b1d3c62. Summary will update on new commits. <a href="https://cubic.dev/pr/akinloluwami/avnac/pull/26?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

