### PR TITLE
docs: add Community Ports section mentioning avnac-vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,28 @@ Right now they cover core areas such as:
 - If you change media proxy behavior, restart the backend before testing export flows that depend on remote images
 - If you are debugging editor behavior, the frontend is the main source of truth
 - If you are debugging old-file compatibility, start with `frontend/src/lib/avnac-scene.ts` and the files/create routes
+
+---
+
+## Community Ports
+
+Avnac has been ported to other frameworks by the community:
+
+### avnac-vue — Vue 3 port
+
+A full Vue 3 + Fabric.js adaptation of Avnac, built for embedding into Vue applications.
+
+- **Repo:** https://github.com/VenMail/avnac-vue
+- **Live demo:** https://venmail.github.io/avnac-vue/
+
+**Additional features in avnac-vue beyond the original:**
+
+| Feature | avnac-vue |
+|---|---|
+| Framework | Vue 3 + Vite + TypeScript (Vue SFCs) |
+| Animations | `motion.dev` animation runtime + PPTX animation export |
+| Present mode | Fullscreen slide presentation with keyboard navigation |
+| Charts | Bar, Stacked Bar, Line, Area, Pie, Doughnut, Scatter, Radar + data dialog |
+| Diagrams & infographics | Pyramid, Funnel, Timeline, Chevron, Venn, Cycle, Accordion, 2x2 Matrix |
+| Cross-canvas copy/paste | Full copy/paste across documents via system clipboard |
+| PPTX import/export | Improved: images, lines, charts, corrected animation XML |


### PR DESCRIPTION
Hi @akinloluwami! This PR adds a **Community Ports** section to the README documenting [avnac-vue](https://github.com/VenMail/avnac-vue) — a Vue 3 + Fabric.js port of Avnac.

**avnac-vue** keeps the same core canvas editing model and keyboard shortcuts while adding:
- `motion.dev` animations + PPTX animation export
- Fullscreen present mode with slide navigation
- Extended chart types (Bar, Stacked Bar, Line, Area, Pie, Doughnut, Scatter, Radar)
- Diagram & infographic templates (Pyramid, Funnel, Timeline, Chevron, Venn, Cycle, etc.)
- Full cross-canvas copy/paste via system clipboard
- Vue SFC architecture for embedding into Vue 3 host apps

Live demo: https://venmail.github.io/avnac-vue/

No code changes — just documentation. Feel free to adjust the wording or section placement as you see fit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/akinloluwami/codesmith/avnac/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Community Ports section to the README highlighting `avnac-vue`, a Vue 3 + Fabric.js port of Avnac. Includes repo/demo links and a small feature table to show key differences (animations, present mode, charts, diagrams, clipboard, PPTX).

<sup>Written for commit 28cc451175f1b564a4d83e387e52b5c61d744fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

